### PR TITLE
Fix errors on missing TERM_NAME in ontology validation; update TERM_NAME

### DIFF
--- a/sdrf_pipelines/sdrf/sdrf_schema.py
+++ b/sdrf_pipelines/sdrf/sdrf_schema.py
@@ -40,8 +40,8 @@ def ontology_term_parser(cell_value: str = None):
     values = cell_value.split(";")
     if len(values) == 1:
         name = values[0].lower()
-    if "=" not in name:
-        term[TERM_NAME] = name
+        if "=" not in name:
+            term[TERM_NAME] = name
     else:
         for name in values:
             value_terms = name.split("=")


### PR DESCRIPTION
This fixes errors seen on ontology term validation when the `TERM_NAME` key is missing.
The reason I saw this error in the first place seems to be that the `TERM_NAME` key was changed from NM to NT in the standard but remained at the old value in the validator.
**Please verify if my understanding is correct.**
This PR changes `TERM_NAME` to `NT`.
It also makes the validator mark cells without `TERM_NAME` as not valid, instead of raising an exception.