### PR TITLE
Properly pass through the warnings from validate_optional

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
This improves the previously added optional format validations so that warnings are actually returned along with other errors as `LogicError` instances. This allows them to be processed in the validation scripts, e.g. in https://github.com/bigbio/proteomics-metadata-standard/pull/281.