### PR TITLE
Make search parameters optional

### DIFF
--- a/sdrf_pipelines/sdrf/sdrf_schema.py
+++ b/sdrf_pipelines/sdrf/sdrf_schema.py
@@ -325,15 +325,15 @@ mass_spectrometry_schema = SDRFSchema([
     SDRFColumn('comment[modification parameters]', [LeadingWhitespaceValidation(), TrailingWhitespaceValidation(),
                                                   OntologyTerm(ontology_name="unimod", not_available=True)],
              allow_empty=True,
-             optional_type=False),
+             optional_type=True),
     SDRFColumn('comment[cleavage agent details]', [LeadingWhitespaceValidation(), TrailingWhitespaceValidation(),
                                                  OntologyTerm("ms")],
              allow_empty=True,
              optional_type=False),
     SDRFColumn('comment[fragment mass tolerance]', [LeadingWhitespaceValidation(), TrailingWhitespaceValidation()],
              allow_empty=True,
-             optional_type=False),
+             optional_type=True),
     SDRFColumn('comment[precursor mass tolerance]', [LeadingWhitespaceValidation(), TrailingWhitespaceValidation()],
              allow_empty=True,
-             optional_type=False)
+             optional_type=True)
 ], min_columns=7)


### PR DESCRIPTION
This change makes precursor and fragment mass tolerances, as well as modifications, optional, as discussed in https://github.com/bigbio/proteomics-metadata-standard/issues/293.