### PR TITLE
Fix SdrfDataframe._constructor signature

### DIFF
--- a/sdrf_pipelines/sdrf/sdrf.py
+++ b/sdrf_pipelines/sdrf/sdrf.py
@@ -9,7 +9,7 @@ from sdrf_pipelines.sdrf.sdrf_schema import human_schema, HUMAN_TEMPLATE, VERTEB
 class SdrfDataFrame(pd.DataFrame):
 
     @property
-    def _constructor(self, template):
+    def _constructor(self):
         """
         This method is makes it so our methods return an instance
         :return:


### PR DESCRIPTION
This fixes the problem that `SdrfDataframe` cannot be indexed with `.loc` because accessing its `_constructor` property always results in an error.