### PR TITLE
Data file distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # Include the README
-include *.md
+include README.md
 
 # Include the license file
 include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,4 @@ include README.md
 include LICENSE
 
 # Include the data files
-recursive-include sdrf_pipelines *.xml
-
+recursive-include sdrf_pipelines *.xml *.yml

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
-from setuptools import setup, find_packages
+
+from setuptools import find_packages
+from setuptools import setup
 
 with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
@@ -13,16 +15,13 @@ setup(
     long_description_content_type="text/markdown",
     long_description=long_description,
     license="'Apache 2.0",
+    data_files=[("", ["LICENSE", "sdrf_pipelines/openms/unimod.xml", "sdrf_pipelines/sdrf_merge/param2sdrf.yml"])],
+    package_data={
+        "": ["*.xml"],
+    },
     url="https://github.com/bigbio/sdrf-pipelines",
     packages=find_packages(),
-    install_requires=[
-        "click",
-        "pandas",
-        "pandas_schema",
-        "requests",
-        "pytest",
-        "pyyaml",
-    ],
+    install_requires=["click", "pandas", "pandas_schema", "requests", "pytest", "pyyaml"],
     entry_points={"console_scripts": ["parse_sdrf = sdrf_pipelines.parse_sdrf:main"]},
     platforms=["any"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,50 @@
 from __future__ import print_function
 from setuptools import setup, find_packages
 
-with open("README.md", "r", encoding='UTF-8') as fh:
-  long_description = fh.read()
+with open("README.md", "r", encoding="UTF-8") as fh:
+    long_description = fh.read()
 
 setup(
-  name="sdrf-pipelines",
-  version="0.0.21",
-  author="BigBio Team",
-  author_email="ypriverol@gmail.com",
-  description="Translate, convert SDRF to configuration pipelines",
-  long_description_content_type="text/markdown",
-  long_description=long_description,
-  license="'Apache 2.0",
-  data_files=[("", ["LICENSE", "sdrf_pipelines/openms/unimod.xml", "sdrf_pipelines/sdrf_merge/param2sdrf.yml"])],
-  package_data={'': ['*.xml'], },
-  url="https://github.com/bigbio/sdrf-pipelines",
-  packages=find_packages(),
-  install_requires=['click', 'pandas', 'pandas_schema', 'requests', 'pytest', 'pyyaml'],
-  entry_points={
-    'console_scripts': [
-      'parse_sdrf = sdrf_pipelines.parse_sdrf:main'
-    ]
-  },
-  platforms=['any'],
-  classifiers=[
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: OS Independent",
-    'Topic :: Scientific/Engineering :: Bio-Informatics'
-  ],
-  keywords='sdrf python multiomics proteomics',
-  include_package_data=True,
-  python_requires='>=3.6',
+    name="sdrf-pipelines",
+    version="0.0.21",
+    author="BigBio Team",
+    author_email="ypriverol@gmail.com",
+    description="Translate, convert SDRF to configuration pipelines",
+    long_description_content_type="text/markdown",
+    long_description=long_description,
+    license="'Apache 2.0",
+    data_files=[
+        (
+            "",
+            [
+                "LICENSE",
+                "sdrf_pipelines/openms/unimod.xml",
+                "sdrf_pipelines/sdrf_merge/param2sdrf.yml",
+            ],
+        )
+    ],
+    package_data={
+        "": ["*.xml"],
+    },
+    url="https://github.com/bigbio/sdrf-pipelines",
+    packages=find_packages(),
+    install_requires=[
+        "click",
+        "pandas",
+        "pandas_schema",
+        "requests",
+        "pytest",
+        "pyyaml",
+    ],
+    entry_points={"console_scripts": ["parse_sdrf = sdrf_pipelines.parse_sdrf:main"]},
+    platforms=["any"],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
+    ],
+    keywords="sdrf python multiomics proteomics",
+    include_package_data=True,
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -13,19 +13,6 @@ setup(
     long_description_content_type="text/markdown",
     long_description=long_description,
     license="'Apache 2.0",
-    data_files=[
-        (
-            "",
-            [
-                "LICENSE",
-                "sdrf_pipelines/openms/unimod.xml",
-                "sdrf_pipelines/sdrf_merge/param2sdrf.yml",
-            ],
-        )
-    ],
-    package_data={
-        "": ["*.xml"],
-    },
     url="https://github.com/bigbio/sdrf-pipelines",
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
Add `*.yml` files to the distributed data file types and cleanup data file collection, i.e. only use the `MANIFEST.in` for data file definition and remove redundant data file definitions from `setup.py`.

Closes #124 