### PR TITLE
Fix if-else branch in column name validation

### DIFF
--- a/sdrf_pipelines/sdrf/sdrf_schema.py
+++ b/sdrf_pipelines/sdrf/sdrf_schema.py
@@ -211,7 +211,7 @@ class SDRFSchema(Schema):
             m = re.match(self._column_template, cname)
             if not m:
                 errors.append(cname)
-            if m.group().startswith("factor value"):
+            elif m.group().startswith("factor value"):
                 if (
                     m.group().replace("factor value", "comment") not in panda_sdrf.columns
                     and m.group().replace("factor value", "characteristics") not in panda_sdrf.columns


### PR DESCRIPTION
If "m" is None (e.g. if the regex failed to match), then the following branch fails via exception, and fails to report errors. This should be an if-else.