### PR TITLE
OLS refactoring. 

### DIFF
--- a/sdrf_pipelines/zooma/ols.py
+++ b/sdrf_pipelines/zooma/ols.py
@@ -27,6 +27,7 @@ API_SEARCH = "/api/search"
 API_SELECT = "/api/select"
 API_TERM = "/api/ontologies/{ontology}/terms/{iri}"
 API_ANCESTORS = "/api/ontologies/{ontology}/terms/{iri}/ancestors"
+API_PROPERTIES = "/api/ontologies/{ontology}/properties?lang=en"
 
 
 def _concat_str_or_list(input_str):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     license="'Apache 2.0",
     data_files=[("", ["LICENSE", "sdrf_pipelines/openms/unimod.xml", "sdrf_pipelines/sdrf_merge/param2sdrf.yml"])],
     package_data={
-        "": ["*.xml"],
+        "": ["*.xml", "*.obo"],
     },
     url="https://github.com/bigbio/sdrf-pipelines",
     packages=find_packages(),

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,0 +1,7 @@
+from sdrf_pipelines.zooma.ols import OlsClient
+
+def test_ontology():
+    ols = OlsClient()
+    ontology_list = ols.search("homo sapiens",ontology="NCBITaxon")
+    print(ontology_list)
+    assert len(ontology_list) > 0


### PR DESCRIPTION
OLS is mainly used to validate the terms for each column of the SDRF. However, OLS could be unstable failing the entire validation. 

The following PR does: 
- [ ] Check if the OLS is running. 
- [ ] Check if the given ontology, for example PSI-MS, is available. 
- [ ] All tests related with the OLSClient are updated. 