### PR TITLE
Add setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "pyarrow",
         "duckdb",
         "rdflib",
+        "setuptools"
     ],
     entry_points={"console_scripts": ["parse_sdrf = sdrf_pipelines.parse_sdrf:main"]},
     platforms=["any"],


### PR DESCRIPTION
### **User description**
Fixes #175.


___

### **PR Type**
dependencies


___

### **Description**
- Added `setuptools` to the `install_requires` list in `setup.py` to ensure it is included as a dependency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Add setuptools to install_requires dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup.py

- Added `setuptools` to the list of install_requires dependencies.



</details>


  </td>
  <td><a href="https://github.com/bigbio/sdrf-pipelines/pull/179/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The package now explicitly requires `setuptools` for installation, ensuring smoother setup for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->