### PR TITLE
test --version and --help CLI options

### DIFF
--- a/sdrf_pipelines/sdrf/validators.py
+++ b/sdrf_pipelines/sdrf/validators.py
@@ -56,7 +56,6 @@ def register_validator(validator_name=None):
 
         # Store the class in the registry
         _VALIDATOR_REGISTRY[validator_name] = cls
-        print(f"Registered {cls.__name__} as {validator_name}")
 
         return cls
 


### PR DESCRIPTION
This PR adds

- One test for the output of `parse_sdrf --version`.
    A print statement executed in the initiation of the program would have broken quantms version extraction logic.
- One test for the output of `parse_sdrf --help`.
    Previously there was simply not test for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added tests to verify the CLI's version output and help message for improved reliability.
- **Chores**
  - Removed an unnecessary debug print statement from internal validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->