### PR TITLE
Updated parsing of combined modifications

### DIFF
--- a/sdrf_pipelines/openms/openms.py
+++ b/sdrf_pipelines/openms/openms.py
@@ -243,7 +243,12 @@ class OpenMS:
 
     def _extract_modification_name(self, mod_string):
         name = re.search("NT=(.+?)(;|$)", mod_string).group(1)
-        name = name.capitalize()
+        # Check for combined modifications like "Phospho+Oxidation"
+        if '+' in name:
+            name = [it.capitalize() for it in name.split('+')]
+            name = '+'.join(name)
+        else:
+            name = name.capitalize()
 
         accession = re.search("AC=(.+?)(;|$)", mod_string).group(1)
         ptm = self._unimod_database.get_by_accession(accession)


### PR DESCRIPTION
### **User description**
Hi all,

here are some proposed changes to parse UNIMOD combined modifications.

- Rational: Comet in the bigbio/quantms pipeline breaks when `Met-loss+Acetyl` is set as a variable modification. The current version of `parse_sdrf convert-openms` converts it to `Met-loss+acetyl`

- By UNIMOD convention, combined modifications should be delimited with '+' (see: https://www.unimod.org/names.html, Rule - 11)
- I propose a minimal implementation. It is likely not solving all UNIMOD combined modifications, since some the `it.capitalize()` might still break some, but I believe the proposed changes should cover the majority.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix parsing of combined UNIMOD modifications delimited with '+'

- Preserve capitalization of individual components in combined modifications

- Prevent incorrect lowercasing that broke Comet pipeline compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Combined Modification<br/>e.g. Met-loss+Acetyl"] -->|Extract Name| B["Split by '+'"]
  B -->|Capitalize Each| C["Met-loss+Acetyl"]
  C -->|Lookup PTM| D["Valid UNIMOD Entry"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>openms.py</strong><dd><code>Handle combined UNIMOD modifications with proper capitalization</code></dd></summary>
<hr>

sdrf_pipelines/openms/openms.py

<ul><li>Added detection for combined modifications containing '+' delimiter<br> <li> Split combined modifications and capitalize each component <br>individually<br> <li> Preserve '+' as separator between modification components<br> <li> Maintain backward compatibility for single modifications</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/sdrf-pipelines/pull/240/files#diff-8229e69a289dbe40b85ae9ca60ee48b888d2efe1dee568f24cd40d6f49b3319d">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of combined protein modification names in OpenMS converter to preserve proper formatting (e.g., "Phospho+Oxidation"), ensuring more accurate downstream identification and name resolution of post-translational modifications from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->