### PR TITLE
Sync sdrf-templates main into pipelines

### DIFF
--- a/src/sdrf_pipelines/sdrf/schemas/registry.py
+++ b/src/sdrf_pipelines/sdrf/schemas/registry.py
@@ -149,9 +149,22 @@ class SchemaRegistry:
         """Load a schema file and return the raw data."""
         with open(schema_path, encoding="utf-8") as f:
             if schema_path.endswith(".json"):
-                return json.load(f)
+                data = json.load(f)
             else:
-                return yaml.safe_load(f)
+                data = yaml.safe_load(f)
+        self._normalize_validator_params(data)
+        return data
+
+    def _normalize_validator_params(self, obj: Any) -> None:
+        """Normalize validators with null params to use an empty dict."""
+        if isinstance(obj, dict):
+            if "validator_name" in obj and obj.get("params") is None:
+                obj["params"] = {}
+            for value in obj.values():
+                self._normalize_validator_params(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                self._normalize_validator_params(item)
 
     def _load_manifest(self) -> dict[str, Any]:
         """Load the templates.yaml manifest file."""

--- a/tests/test_schema_registry.py
+++ b/tests/test_schema_registry.py
@@ -1,0 +1,18 @@
+"""Regression tests for schema loading."""
+
+from sdrf_pipelines.sdrf.schemas import SchemaRegistry
+
+
+def test_schema_registry_normalizes_null_validator_params():
+    """Templates with validators that omit params should still load cleanly."""
+    registry = SchemaRegistry()
+
+    assert "ms-metabolomics" in registry.schemas
+
+    has_empty_params = any(
+        validator.params == {}
+        for schema in registry.schemas.values()
+        for column in schema.columns
+        for validator in column.validators
+    )
+    assert has_empty_params


### PR DESCRIPTION
## Summary
- update the vendored `sdrf-templates` submodule to the latest `main` commit (`930056b`)
- normalize schema validators that use `params: null` so the current stable templates load cleanly
- add a regression test for `SchemaRegistry` against the updated template set

## Validation
- `uv run pytest tests/test_schema_registry.py tests/test_skip_ontology.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schema loading to properly normalize validator parameters, ensuring consistent handling of empty parameter configurations.

* **Tests**
  * Added regression test for validator parameter normalization.

* **Chores**
  * Updated schema templates submodule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->