### PR TITLE
Add automated sdrf-templates sync workflow

### DIFF
--- a/.github/workflows/sync-sdrf-templates.yml
+++ b/.github/workflows/sync-sdrf-templates.yml
@@ -1,0 +1,107 @@
+name: Sync sdrf-templates
+
+on:
+  repository_dispatch:
+    types: [sync-sdrf-templates]
+  workflow_dispatch:
+    inputs:
+      templates_sha:
+        description: "Optional sdrf-templates commit SHA to sync"
+        required: false
+      templates_ref:
+        description: "Branch or ref to fetch from sdrf-templates"
+        required: false
+        default: "main"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Resolve target templates commit
+        id: vars
+        env:
+          PAYLOAD_SHA: ${{ github.event.client_payload.templates_sha }}
+          PAYLOAD_REF: ${{ github.event.client_payload.templates_ref }}
+          INPUT_SHA: ${{ github.event.inputs.templates_sha }}
+          INPUT_REF: ${{ github.event.inputs.templates_ref }}
+          SUBMODULE_PATH: src/sdrf_pipelines/sdrf/sdrf-templates
+        run: |
+          set -euo pipefail
+
+          templates_sha="${PAYLOAD_SHA:-${INPUT_SHA:-}}"
+          templates_ref="${PAYLOAD_REF:-${INPUT_REF:-main}}"
+
+          git -C "${SUBMODULE_PATH}" fetch origin "${templates_ref}"
+
+          if [ -z "${templates_sha}" ]; then
+            templates_sha="$(git -C "${SUBMODULE_PATH}" rev-parse "origin/${templates_ref}")"
+          fi
+
+          echo "templates_sha=${templates_sha}" >> "${GITHUB_OUTPUT}"
+          echo "templates_short_sha=${templates_sha:0:7}" >> "${GITHUB_OUTPUT}"
+          echo "templates_ref=${templates_ref}" >> "${GITHUB_OUTPUT}"
+
+      - name: Update sdrf-templates submodule
+        env:
+          SUBMODULE_PATH: src/sdrf_pipelines/sdrf/sdrf-templates
+          TEMPLATES_SHA: ${{ steps.vars.outputs.templates_sha }}
+        run: |
+          set -euo pipefail
+
+          git submodule sync --recursive
+          git submodule update --init --recursive
+          git -C "${SUBMODULE_PATH}" checkout "${TEMPLATES_SHA}"
+          git add "${SUBMODULE_PATH}"
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Run focused validation
+        run: |
+          uv sync
+          uv run pytest tests/test_schema_registry.py tests/test_skip_ontology.py
+          git diff --check
+
+      - name: Open or update sync PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: >-
+            chore: sync sdrf-templates main to
+            ${{ steps.vars.outputs.templates_short_sha }}
+          branch: automation/sync-sdrf-templates-main
+          delete-branch: true
+          base: main
+          title: >-
+            Sync sdrf-templates main
+            (${{ steps.vars.outputs.templates_short_sha }})
+          body: |
+            This automated PR syncs the vendored `sdrf-templates` submodule to the latest stable templates state.
+
+            - Source repository: `bigbio/sdrf-templates`
+            - Source ref: `${{ steps.vars.outputs.templates_ref }}`
+            - Source commit: `${{ steps.vars.outputs.templates_sha }}`
+            - Trigger: `${{ github.event_name }}`
+
+            Validation run in this workflow:
+            - `uv sync`
+            - `uv run pytest tests/test_schema_registry.py tests/test_skip_ontology.py`
+            - `git diff --check`


### PR DESCRIPTION
## Summary
- add a `repository_dispatch` listener that syncs the vendored `sdrf-templates` submodule
- run focused validation after the bump
- open or update a PR automatically using `peter-evans/create-pull-request`

## Notes
- the workflow also supports `workflow_dispatch` for manual testing
- future sync PRs will target `main`
- the trigger event is expected from `bigbio/sdrf-templates` after merges to `main`