### PR TITLE
fix: --lib-fixed-mod mTRAQ

### DIFF
--- a/src/sdrf_pipelines/converters/diann/diann.py
+++ b/src/sdrf_pipelines/converters/diann/diann.py
@@ -624,7 +624,8 @@ class DiaNN(BaseConverter):
             mod_name = PLEXDIA_REGISTRY[plex_info["type"]]["fixed_mod"]["name"]
 
             # Note that: According to DIA-NN:
-            # --lib-fixed-mod is no longer necessary as the library generated in Step 1 already contains (mTRAQ) at the N-terminus and lysines of each peptide.
+            # --lib-fixed-mod is no longer necessary as the library generated in Step 1
+            # already contains (mTRAQ) at the N-terminus and lysines of each peptide.
             if mod_name != "mTRAQ":
                 parts.append(f"--lib-fixed-mod {mod_name}")
             parts.append("--original-mods")

--- a/src/sdrf_pipelines/converters/diann/diann.py
+++ b/src/sdrf_pipelines/converters/diann/diann.py
@@ -622,7 +622,11 @@ class DiaNN(BaseConverter):
             from sdrf_pipelines.converters.diann.constants import PLEXDIA_REGISTRY
 
             mod_name = PLEXDIA_REGISTRY[plex_info["type"]]["fixed_mod"]["name"]
-            parts.append(f"--lib-fixed-mod {mod_name}")
+
+            # Note that: According to DIA-NN: 
+            # --lib-fixed-mod is no longer necessary as the library generated in Step 1 already contains (mTRAQ) at the N-terminus and lysines of each peptide.
+            if mod_name != "mTRAQ":
+                parts.append(f"--lib-fixed-mod {mod_name}")
             parts.append("--original-mods")
 
         # Global mass accuracy tolerances (max across all runs for in-silico library generation)

--- a/src/sdrf_pipelines/converters/diann/diann.py
+++ b/src/sdrf_pipelines/converters/diann/diann.py
@@ -623,7 +623,7 @@ class DiaNN(BaseConverter):
 
             mod_name = PLEXDIA_REGISTRY[plex_info["type"]]["fixed_mod"]["name"]
 
-            # Note that: According to DIA-NN: 
+            # Note that: According to DIA-NN:
             # --lib-fixed-mod is no longer necessary as the library generated in Step 1 already contains (mTRAQ) at the N-terminus and lysines of each peptide.
             if mod_name != "mTRAQ":
                 parts.append(f"--lib-fixed-mod {mod_name}")

--- a/tests/test_convert_diann.py
+++ b/tests/test_convert_diann.py
@@ -77,7 +77,6 @@ class TestDiannMtraq:
         assert "mTRAQ,0,nK,0:0" in content
         assert "mTRAQ,4,nK,4.0070994:4.0070994" in content
         assert "--fixed-mod mTRAQ,140.0949630177,nK" in content
-        assert "--lib-fixed-mod mTRAQ" in content
         assert "--original-mods" in content
 
     def test_mtraq_filemap_has_labels(self, diann_data_dir, on_tmpdir):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * mTRAQ-labelled data no longer triggers the library fixed-mod flag while still reporting original modifications, preventing incorrect DIA-NN/plexDIA configuration for mTRAQ analyses.

* **Tests**
  * Updated tests to stop requiring the suppressed library fixed-mod flag for mTRAQ, while keeping other mTRAQ-related checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->