### PR TITLE
fix(diann): merge multi-residue modifications into a single entry (Oxidation on P / pT,pY dropped)

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -44,15 +44,17 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          conda install -n sdrf-pipelines-build conda-build conda-verify anaconda-client
+          # conda-build registers the `conda build` subcommand on the conda it is
+          # installed into; the running CLI is base conda, so install into base.
+          conda install -n base -c conda-forge conda-build conda-verify anaconda-client
 
       - name: Verify conda recipe
         run: |
-          conda-verify .
+          conda run -n base conda-verify .
 
       - name: Build and test the sdrf-pipelines package
         run: |
           # conda build automatically runs the tests defined in meta.yaml test section
-          conda build --package-format .tar.bz2 recipe
+          conda run -n base conda build --package-format .tar.bz2 recipe
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ env.SETUPTOOLS_SCM_PRETEND_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   declared across several SDRF cells (`Oxidation` on `M` and on `P`) is merged into a single entry
   (`Oxidation,15.994915,MP`).
 
+### Chores
+- Bump `idna` to 3.18 in `uv.lock` (supersedes Dependabot #304, which targeted 3.15).
+- CI: fix the Conda Build workflow — install `conda-build`/`conda-verify` into the `base` env and invoke
+  via `conda run -n base`, so the `conda build` subcommand is registered (was failing with
+  `conda: error: argument COMMAND: invalid choice: 'build'`).
+
 ## Version 1.0.0 From 0.0.32
 
 ### Development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # History of changes for sdrf-pipelines
 
+## Version 0.1.5
+
+### Bug Fixes
+- DIA-NN converter (`converters/diann/modifications.py`): correctly handle modifications that target
+  multiple residues. DIA-NN keeps only the first residue of a comma-separated site list and
+  de-duplicates `--var-mod`/`--fixed-mod` entries by name, so the previous output silently dropped
+  every residue except the first (e.g. all hydroxyproline `Oxidation` on `P`, and all `pT`/`pY`
+  phosphosites). Sites declared in a single SDRF cell (`TA=S,T,Y`) are now concatenated into one
+  DIA-NN site string (`Phospho,79.966331,STY`), and the same modification (same name + mass)
+  declared across several SDRF cells (`Oxidation` on `M` and on `P`) is merged into a single entry
+  (`Oxidation,15.994915,MP`).
+
 ## Version 1.0.0 From 0.0.32
 
 ### Development

--- a/src/sdrf_pipelines/converters/diann/modifications.py
+++ b/src/sdrf_pipelines/converters/diann/modifications.py
@@ -7,12 +7,38 @@ from sdrf_pipelines.converters.openms.unimod import UnimodDatabase
 # Modification names that indicate isobaric/isotopic labels
 _LABEL_MOD_PREFIXES = ("TMT", "iTRAQ", "Label")
 
+# SDRF terminal target notations -> DIA-NN site tokens
+_TERMINAL_SITE_MAP = {
+    "Protein N-term": "*n",
+    "N-term": "n",
+    "Any N-term": "n",
+    "Protein C-term": "*c",
+    "C-term": "c",
+    "Any C-term": "c",
+}
+
 
 class DiannModificationConverter:
     """Converts SDRF modification strings to DIA-NN notation.
 
-    DIA-NN format: Name,DeltaMass,Site[,label]
-    The optional 'label' suffix indicates isotopic labels that don't affect RT.
+    DIA-NN format: ``Name,DeltaMass,Sites[,label]``. ``Sites`` is a single
+    *concatenated* string of target residues/termini **without separators**
+    (e.g. ``STY``, ``MP``, ``nK``); the comma only ever delimits the optional
+    fourth ``label`` field.
+
+    DIA-NN keeps only the first residue of a comma-separated site list and
+    de-duplicates ``--var-mod``/``--fixed-mod`` entries by modification name, so
+    a modification targeting several residues must be emitted as a single entry
+    with the sites concatenated. Two SDRF representations would otherwise be
+    silently truncated by DIA-NN, dropping every residue except the first:
+
+    * a single SDRF cell with comma-separated targets (``TA=S,T,Y``); and
+    * the same modification (same name + mass) declared across several SDRF
+      cells with different targets (``Oxidation`` on ``M`` and on ``P``).
+
+    This converter handles both: it concatenates multi-residue sites within a
+    cell (``TA=S,T,Y`` -> ``STY``) and merges same-(name, mass) modifications
+    across cells (``Oxidation`` ``M`` + ``P`` -> ``Oxidation,15.994915,MP``).
     """
 
     def __init__(self):
@@ -23,28 +49,24 @@ class DiannModificationConverter:
 
         Args:
             mod_string: SDRF mod string (e.g., "NT=Carbamidomethyl;TA=C;MT=fixed;AC=UNIMOD:4")
-            is_fixed: Whether this is a fixed modification
+            is_fixed: Whether this is a fixed modification (kept for API compatibility)
 
         Returns:
-            DIA-NN format string (e.g., "Carbamidomethyl,57.021464,C")
+            DIA-NN format string (e.g., "Carbamidomethyl,57.021464,C"). Multi-residue
+            sites declared in one cell are concatenated (e.g. "Phospho,79.966331,STY").
 
         Raises:
-            ValueError: If modification not found in Unimod
+            ValueError: If modification not found in Unimod or has no target site
         """
-        name = self._extract_name(mod_string)
-        site = self._extract_site(mod_string)
-        delta_mass = self._get_delta_mass(name, mod_string)
-
-        parts = [name, str(delta_mass), site]
-
-        # Add 'label' suffix for isobaric label modifications
-        if any(name.startswith(prefix) for prefix in _LABEL_MOD_PREFIXES):
-            parts.append("label")
-
-        return ",".join(parts)
+        name, delta_mass, sites, is_label = self._parse_modification(mod_string)
+        return self._format(name, delta_mass, sites, is_label)
 
     def convert_all_modifications(self, fixed_mods: list[str], var_mods: list[str]) -> tuple[list[str], list[str]]:
         """Convert lists of SDRF modifications to DIA-NN format.
+
+        Modifications sharing the same name and delta mass are merged into a
+        single DIA-NN entry with their target sites combined, so DIA-NN does not
+        silently drop residues (see the class docstring).
 
         Args:
             fixed_mods: List of SDRF fixed modification strings
@@ -53,18 +75,48 @@ class DiannModificationConverter:
         Returns:
             Tuple of (fixed_diann_mods, var_diann_mods)
         """
-        fixed_result = []
-        var_result = []
+        return self._convert_and_merge(fixed_mods), self._convert_and_merge(var_mods)
 
-        for mod in fixed_mods:
-            if mod.strip():
-                fixed_result.append(self.convert_modification(mod, is_fixed=True))
+    def _convert_and_merge(self, mods: list[str]) -> list[str]:
+        """Convert and merge SDRF modification strings.
 
-        for mod in var_mods:
-            if mod.strip():
-                var_result.append(self.convert_modification(mod, is_fixed=False))
+        Entries sharing ``(name, delta_mass, is_label)`` are combined into one,
+        accumulating their target sites. The first-seen order of distinct
+        modifications is preserved.
+        """
+        order: list[tuple] = []
+        merged: dict[tuple, dict] = {}
+        for mod in mods:
+            if not mod or not mod.strip():
+                continue
+            name, delta_mass, sites, is_label = self._parse_modification(mod)
+            key = (name, delta_mass, is_label)
+            if key not in merged:
+                merged[key] = {"name": name, "mass": delta_mass, "sites": [], "label": is_label}
+                order.append(key)
+            for token in sites:
+                if token not in merged[key]["sites"]:
+                    merged[key]["sites"].append(token)
+        return [self._format(m["name"], m["mass"], m["sites"], m["label"]) for m in (merged[key] for key in order)]
 
-        return fixed_result, var_result
+    def _format(self, name: str, delta_mass: float, sites: list[str], is_label: bool) -> str:
+        """Assemble a DIA-NN modification string from its components.
+
+        Site tokens are concatenated (no separators), sorted for deterministic
+        output; the comma-delimited ``label`` flag is appended for labels only.
+        """
+        parts = [name, str(delta_mass), "".join(sorted(set(sites)))]
+        if is_label:
+            parts.append("label")
+        return ",".join(parts)
+
+    def _parse_modification(self, mod_string: str) -> tuple[str, float, list[str], bool]:
+        """Parse an SDRF modification string into (name, delta_mass, site tokens, is_label)."""
+        name = self._extract_name(mod_string)
+        sites = self._extract_sites(mod_string)
+        delta_mass = self._get_delta_mass(name, mod_string)
+        is_label = any(name.startswith(prefix) for prefix in _LABEL_MOD_PREFIXES)
+        return name, delta_mass, sites, is_label
 
     def _extract_name(self, mod_string: str) -> str:
         """Extract and validate modification name via Unimod lookup."""
@@ -86,28 +138,36 @@ class DiannModificationConverter:
 
         return ptm.get_name()
 
-    def _extract_site(self, mod_string: str) -> str:
-        """Extract target site and convert to DIA-NN notation."""
+    def _extract_sites(self, mod_string: str) -> list[str]:
+        """Extract target site(s) and convert to DIA-NN site tokens.
+
+        Handles a single residue (``TA=M``), a comma-separated residue list in a
+        single cell (``TA=S,T,Y``), and terminal notations (``PP=Protein
+        N-term``). Returns a de-duplicated list of DIA-NN site tokens.
+        """
         ta_match = re.search(r"TA=(.+?)(;|$)", mod_string)
         pp_match = re.search(r"PP=(.+?)(;|$)", mod_string)
 
         if ta_match:
-            site = ta_match.group(1)
+            raw = ta_match.group(1)
         elif pp_match:
-            site = pp_match.group(1)
+            raw = pp_match.group(1)
         else:
             raise ValueError(f"No target site (TA= or PP=) in: {mod_string}")
 
-        # Convert to DIA-NN site notation
-        if site == "Protein N-term":
-            return "*n"
-        elif site in ("N-term", "Any N-term"):
-            return "n"
-        elif site == "Protein C-term":
-            return "*c"
-        elif site in ("C-term", "Any C-term"):
-            return "c"
-        return site
+        tokens: list[str] = []
+        for part in raw.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            # Convert to DIA-NN site notation; residues map to themselves
+            token = _TERMINAL_SITE_MAP.get(part, part)
+            if token not in tokens:
+                tokens.append(token)
+
+        if not tokens:
+            raise ValueError(f"No target site (TA= or PP=) in: {mod_string}")
+        return tokens
 
     def _get_delta_mass(self, name: str, mod_string: str) -> float:
         """Get monoisotopic delta mass from Unimod."""

--- a/tests/test_diann_modifications.py
+++ b/tests/test_diann_modifications.py
@@ -52,3 +52,64 @@ class TestDiannModificationConverter:
         assert fixed_result[0] == "Carbamidomethyl,57.021464,C"
         assert len(var_result) == 1
         assert var_result[0] == "Oxidation,15.994915,M"
+
+    # --- multi-residue sites in a single SDRF cell (TA=S,T,Y) -----------------
+    # DIA-NN keeps only the first residue of a comma-separated site list, so the
+    # converter must concatenate the residues into one site string.
+
+    def test_var_mod_multi_site_single_cell_phospho(self):
+        converter = DiannModificationConverter()
+        result = converter.convert_modification("NT=Phospho;MT=variable;TA=S,T,Y;AC=UNIMOD:21", is_fixed=False)
+        assert result == "Phospho,79.966331,STY"
+
+    def test_var_mod_multi_site_single_cell_oxidation_mp(self):
+        converter = DiannModificationConverter()
+        result = converter.convert_modification("NT=Oxidation;MT=variable;TA=M,P;AC=UNIMOD:35", is_fixed=False)
+        assert result == "Oxidation,15.994915,MP"
+
+    def test_var_mod_multi_site_with_spaces(self):
+        converter = DiannModificationConverter()
+        result = converter.convert_modification("NT=Phospho;MT=variable;TA=S, T, Y;AC=UNIMOD:21", is_fixed=False)
+        assert result == "Phospho,79.966331,STY"
+
+    # --- same modification declared across several SDRF cells ------------------
+    # DIA-NN de-duplicates entries by name and would keep only the first cell,
+    # so same-(name, mass) modifications must be merged into one entry.
+
+    def test_merge_oxidation_m_and_p_across_cells(self):
+        converter = DiannModificationConverter()
+        var_mods = [
+            "NT=Oxidation;MT=variable;TA=M;AC=UNIMOD:35",
+            "NT=Oxidation;MT=variable;TA=P;AC=UNIMOD:35",
+        ]
+        _, var_result = converter.convert_all_modifications([], var_mods)
+        assert var_result == ["Oxidation,15.994915,MP"]
+
+    def test_merge_phospho_across_three_cells(self):
+        converter = DiannModificationConverter()
+        var_mods = [
+            "NT=Phospho;MT=variable;TA=S;AC=UNIMOD:21",
+            "NT=Phospho;MT=variable;TA=T;AC=UNIMOD:21",
+            "NT=Phospho;MT=variable;TA=Y;AC=UNIMOD:21",
+        ]
+        _, var_result = converter.convert_all_modifications([], var_mods)
+        assert var_result == ["Phospho,79.966331,STY"]
+
+    def test_merge_preserves_distinct_modifications(self):
+        converter = DiannModificationConverter()
+        var_mods = [
+            "NT=Oxidation;MT=variable;TA=M;AC=UNIMOD:35",
+            "NT=Oxidation;MT=variable;TA=P;AC=UNIMOD:35",
+            "NT=Acetyl;MT=variable;PP=Protein N-term;AC=UNIMOD:1",
+        ]
+        _, var_result = converter.convert_all_modifications([], var_mods)
+        assert var_result == ["Oxidation,15.994915,MP", "Acetyl,42.010565,*n"]
+
+    def test_merge_deduplicates_repeated_site(self):
+        converter = DiannModificationConverter()
+        var_mods = [
+            "NT=Oxidation;MT=variable;TA=M;AC=UNIMOD:35",
+            "NT=Oxidation;MT=variable;TA=M;AC=UNIMOD:35",
+        ]
+        _, var_result = converter.convert_all_modifications([], var_mods)
+        assert var_result == ["Oxidation,15.994915,M"]

--- a/uv.lock
+++ b/uv.lock
@@ -412,11 +412,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

When an SDRF declares a modification on **multiple residues**, the DIA-NN converter produced flags that DIA-NN silently truncates to the **first residue only**. DIA-NN (a) keeps only the first residue of a comma-separated site list, and (b) de-duplicates `--var-mod`/`--fixed-mod` entries by modification *name*. Both SDRF idioms hit this:

| SDRF | converter emitted (before) | DIA-NN actually used |
|------|----------------------------|----------------------|
| one cell `TA=S,T,Y` | `Phospho,79.966331,S,T,Y` | **S only** (T, Y dropped) |
| `Oxidation` on `M` and on `P` (two cells) | `Oxidation,…,M` + `Oxidation,…,P` | **M only** (P dropped) |

**Impact (confirmed on real data):** all hydroxyproline (`Oxidation` on `P`) was lost in a collagen/ECM IPF DIA‑NN library (1,438 Ox‑P precursors in the reference run → 0), and on a phospho‑enriched dataset every `pT`/`pY` site was dropped (S‑only).

This was verified directly against DIA‑NN 1.8.1 and 2.5.1: `--var-mod Oxidation,15.994915,M --var-mod Oxidation,15.994915,P` → 0 hydroxyproline; the single combined‑site form `--var-mod Oxidation,15.994915,MP` → 49,952. Likewise `--var-mod Phospho,79.966331,S,T,Y` → S only.

The DIA-NN docs confirm the correct syntax is concatenated sites with the comma reserved for the `label` field (`SILAC,0.0,KR,label`, `mTRAQ,140.09,nK`).

## Fix

`converters/diann/modifications.py`:
- Concatenate multi-residue sites declared in a single SDRF cell (`TA=S,T,Y` → `Phospho,79.966331,STY`).
- Merge modifications sharing the same name + delta mass across multiple SDRF cells into one entry (`Oxidation` `M` + `P` → `Oxidation,15.994915,MP`), preserving the `label` flag and first-seen modification order.

`_extract_modifications` reads each SDRF cell as a whole string, so this needs no changes upstream of the converter and does not crash on a single `TA=S,T,Y` cell.

## Tests
Added regression tests for both idioms (single-cell comma list and same-mod-across-cells), plus dedup and distinct-mod-preservation. `69 passed` across diann/plexdia/modification tests; full existing suite unaffected.
