### PR TITLE
Updated tool installation for multi-shell compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ uv:
 
 ```bash
 # Install
-uv tool install sdrf-pipelines[all]
+uv tool install "sdrf-pipelines[all]"
 
 # Validate your SDRF file
 parse_sdrf validate-sdrf --sdrf_file your_file.sdrf.tsv
@@ -25,7 +25,7 @@ pipx:
 
 ```bash
 # Install
-pipx install sdrf-pipelines[all]
+pipx install "sdrf-pipelines[all]"
 
 # Validate your SDRF file
 parse_sdrf validate-sdrf --sdrf_file your_file.sdrf.tsv


### PR DESCRIPTION
Added quotation of uv and pipx installation command to avoid errors with zsh globbing syntax.

Fixes #307.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation examples to quote the `sdrf-pipelines[all]` package specifier in both `uv tool install` and `pipx install` commands.
  * Kept the rest of the README unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->