### PR TITLE
feat(validators): add column_name_validator to catch malformed column headers

### DIFF
--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -307,6 +307,55 @@ class TrailingWhitespaceValidator(SDRFValidator):
                 return []
 
 
+@register_validator(validator_name="column_name_validator")
+class ColumnNameValidator(SDRFValidator):
+    """Validate SDRF column-name syntax: no stray whitespace around the brackets.
+
+    SDRF column names are space-sensitive, so ``characteristics [organism]`` (space before the
+    bracket) and ``characteristics[organism ]`` (space inside the brackets) are *different*,
+    unrecognised columns whose data is silently ignored downstream while the file still validates.
+    This flags a space immediately before ``[`` or on either inside edge of the brackets. Leading/
+    trailing whitespace on the whole name is handled by :class:`TrailingWhitespaceValidator`.
+    """
+
+    # space before '[', space just after '[', or space just before ']'
+    _BRACKET_WHITESPACE: ClassVar[re.Pattern] = re.compile(r"\s\[|\[\s|\s\]")
+
+    def _check_name(self, name: str) -> LogicError | None:
+        if isinstance(name, str) and self._BRACKET_WHITESPACE.search(name):
+            return LogicError.from_code(
+                ErrorCode.MALFORMED_COLUMN_NAME,
+                value=name,
+                row=-1,
+                column=name,
+                error_type=logging.ERROR,
+                suggestion=(
+                    "SDRF column names are space-sensitive. Use e.g. 'characteristics[organism]' - "
+                    "no space before '[' and none inside the brackets."
+                ),
+            )
+        return None
+
+    def _column_names(self, value: Any) -> list[str]:
+        match value:
+            case SDRFDataFrame():
+                return list(value.get_original_columns())
+            case pd.DataFrame():
+                return [str(c) for c in value.columns]
+            case list():
+                return [str(c) for c in value]
+            case str():
+                return [value]
+            case _:
+                return []
+
+    def validate(  # type: ignore[override]
+        self, value: SDRFDataFrame | pd.DataFrame | list[str] | str, column_name: str | None = None
+    ) -> list[LogicError]:
+        """Return a MALFORMED_COLUMN_NAME error for every column name with whitespace around its brackets."""
+        return [err for name in self._column_names(value) if (err := self._check_name(name)) is not None]
+
+
 @register_validator(validator_name="min_columns")
 class MinimumColumns(SDRFValidator):
     minimum_columns: int = config.validation.minimum_columns

--- a/src/sdrf_pipelines/utils/error_codes.py
+++ b/src/sdrf_pipelines/utils/error_codes.py
@@ -35,6 +35,7 @@ class ErrorCode(str, Enum):
     COMMENT_BEFORE_ASSAY = "COMMENT_BEFORE_ASSAY"
     TECHNOLOGY_TYPE_MISPLACED = "TECHNOLOGY_TYPE_MISPLACED"
     FACTOR_COLUMN_NOT_LAST = "FACTOR_COLUMN_NOT_LAST"
+    MALFORMED_COLUMN_NAME = "MALFORMED_COLUMN_NAME"
 
     # Format errors
     TRAILING_WHITESPACE = "TRAILING_WHITESPACE"
@@ -80,6 +81,7 @@ _ERROR_CATEGORY_MAP = {
     ErrorCode.COMMENT_BEFORE_ASSAY: ErrorCategory.STRUCTURE,
     ErrorCode.TECHNOLOGY_TYPE_MISPLACED: ErrorCategory.STRUCTURE,
     ErrorCode.FACTOR_COLUMN_NOT_LAST: ErrorCategory.STRUCTURE,
+    ErrorCode.MALFORMED_COLUMN_NAME: ErrorCategory.STRUCTURE,
     # Format
     ErrorCode.TRAILING_WHITESPACE: ErrorCategory.FORMAT,
     ErrorCode.TRAILING_WHITESPACE_COLUMN_NAME: ErrorCategory.FORMAT,
@@ -118,6 +120,10 @@ ERROR_MESSAGE_TEMPLATES: dict[ErrorCode, str] = {
     ErrorCode.COMMENT_BEFORE_ASSAY: "The column '{column}' cannot be before the assay name",
     ErrorCode.TECHNOLOGY_TYPE_MISPLACED: "The column '{column}' must be immediately after the assay name",
     ErrorCode.FACTOR_COLUMN_NOT_LAST: "The following factor column should be last: {columns}",
+    ErrorCode.MALFORMED_COLUMN_NAME: (
+        "Column name '{value}' is malformed: SDRF column names are space-sensitive - "
+        "there must be no space before '[' or inside the brackets"
+    ),
     # Format
     ErrorCode.TRAILING_WHITESPACE: "Trailing whitespace detected",
     ErrorCode.TRAILING_WHITESPACE_COLUMN_NAME: "Trailing whitespace detected in column name",

--- a/tests/test_column_name_validator.py
+++ b/tests/test_column_name_validator.py
@@ -1,0 +1,48 @@
+"""Tests for ColumnNameValidator: SDRF column names must have no whitespace around the brackets."""
+
+import logging
+
+import pandas as pd
+
+from sdrf_pipelines.sdrf.sdrf import SDRFDataFrame
+from sdrf_pipelines.sdrf.validators import ColumnNameValidator, get_validator
+from sdrf_pipelines.utils.error_codes import ErrorCode
+
+GOOD = [
+    "source name",
+    "characteristics[organism]",
+    "comment[modification parameters]",
+    "comment[ms2 mass analyzer]",
+    "assay name",
+]
+BAD = [
+    "characteristics [organism]",  # space before '['
+    "characteristics[ organism]",  # space after '['
+    "comment[modification parameters ]",  # space before ']'
+]
+
+
+def test_registered_by_name():
+    assert get_validator("column_name_validator") is ColumnNameValidator
+
+
+def test_flags_only_bracket_whitespace():
+    errors = ColumnNameValidator().validate(GOOD + BAD)
+    assert {e.value for e in errors} == set(BAD)
+    assert all(e.error_code == ErrorCode.MALFORMED_COLUMN_NAME for e in errors)
+    assert all(e.error_type == logging.ERROR for e in errors)
+
+
+def test_clean_names_pass():
+    assert ColumnNameValidator().validate(GOOD) == []
+
+
+def test_does_not_double_flag_trailing_whitespace():
+    # Trailing whitespace *after* the closing bracket is TrailingWhitespaceValidator's job, not ours.
+    assert ColumnNameValidator().validate(["characteristics[organism] "]) == []
+
+
+def test_dataframe_and_sdrf_dataframe_paths():
+    df = pd.DataFrame({c: ["x"] for c in ["source name", "characteristics[organism ]", "assay name"]})
+    assert [e.value for e in ColumnNameValidator().validate(df)] == ["characteristics[organism ]"]
+    assert [e.value for e in ColumnNameValidator().validate(SDRFDataFrame(df))] == ["characteristics[organism ]"]

--- a/uv.lock
+++ b/uv.lock
@@ -1405,11 +1405,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds a registered `column_name_validator` plus `ErrorCode.MALFORMED_COLUMN_NAME` (STRUCTURE). It flags column names with whitespace immediately before `[`, or on either inside edge of the brackets (`[ ` / ` ]`). Leading and trailing whitespace on the whole name stays with the existing `trailing_whitespace_validator`, so there is no double-flagging.

## Why

SDRF column names are space-sensitive, so `characteristics [organism]` (space before the bracket) and `comment[modification parameters ]` (space inside the brackets) are treated as *different*, unrecognised columns. Their data is silently dropped while the file still passes validation, so the defect is invisible today.

## Real-world examples this would catch

Malformed headers already present in the corpus, cleaned up in bigbio/sdrf-annotated-datasets#32, for example `comment[modification parameters ]` (space before the closing bracket). Such a file validates cleanly today; with this check it is flagged.

## Tests

Direct unit tests for the validator (`tests/test_column_name_validator.py`): registry lookup, the list / DataFrame / SDRFDataFrame input paths, clean names passing, and that post-bracket trailing whitespace is not double-flagged. The full suite passes (322 passed).

## Wiring, dependency and merge order

The validator runs when declared in the base schema, done in the companion PR bigbio/sdrf-templates#50. Merge that templates PR first, then bump the `sdrf-templates` submodule here to its merge commit to activate the check in CI. This branch deliberately does not bump the submodule, since CI clones it from bigbio and the wiring commit must live there first.

## Scope notes

* The pandas de-duplication suffix (`comment[modification parameters].1`) is not checked: read through pandas it is indistinguishable from legitimate repeated columns, which SDRF allows, so it would false-positive.
* Non-canonical synonyms/typos (`comment[ms2 analyzer type]`, `comment[technical replcate]`) and missing-space names (`sourcename`) are naming normalisation, a separate concern from this whitespace/bracket check.
