### PR TITLE
fix(openms): treat comment[file uri] as optional in convert-openms (#313)

### DIFF
--- a/src/sdrf_pipelines/converters/openms/openms.py
+++ b/src/sdrf_pipelines/converters/openms/openms.py
@@ -410,7 +410,9 @@ class OpenMS:
         raws = []
 
         for _, row in sdrf.iterrows():
-            URI = row["comment[file uri]"]
+            # comment[file uri] is optional in SDRF-Proteomics; fall back to the
+            # (required) data file name when the column is absent (see issue #313).
+            URI = row.get("comment[file uri]", row["comment[data file]"])
             raw = row["comment[data file]"]
 
             if "comment[proteomics data acquisition method]" not in row:

--- a/tests/test_convert_openms.py
+++ b/tests/test_convert_openms.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from sdrf_pipelines.parse_sdrf import cli
@@ -53,6 +54,34 @@ def test_convert_openms(shared_datadir, on_tmpdir):
     result = run_and_check_status_code(cli, ["convert-openms", "-t2", "-s", test_sdrf])
     assert "ERROR" not in result.output.upper(), result.output
     _check_output_existance(on_tmpdir)
+
+
+def test_convert_openms_without_file_uri(shared_datadir, on_tmpdir):
+    """Regression test for issue #313.
+
+    ``comment[file uri]`` is optional in SDRF-Proteomics. ``convert-openms`` used to
+    read it unconditionally and crash with ``KeyError: 'comment[file uri]'`` on SDRFs
+    that do not have that column. Ensure conversion succeeds and the URI falls back to
+    the (required) data file name.
+    """
+    src_sdrf = shared_datadir / "PXD001819/PXD001819.sdrf.tsv"
+    df = pd.read_csv(src_sdrf, sep="\t", dtype=str)
+    assert "comment[file uri]" in df.columns, "fixture expected to have comment[file uri]"
+    df = df.drop(columns=["comment[file uri]"])
+
+    test_sdrf = shared_datadir / "PXD001819/PXD001819.no_file_uri.sdrf.tsv"
+    df.to_csv(test_sdrf, sep="\t", index=False)
+
+    result = run_and_check_status_code(cli, ["convert-openms", "-t2", "-s", test_sdrf])
+    assert "ERROR" not in result.output.upper(), result.output
+    _check_output_existance(on_tmpdir)
+
+    # URI (column 0) must fall back to the data file name (column 1).
+    with open(on_tmpdir / "openms.tsv", "r") as f:
+        rows = [line.rstrip("\n").split("\t") for line in f.readlines()[1:]]
+    assert rows, "openms.tsv has no data rows"
+    for row in rows:
+        assert row[0] == row[1], f"URI did not fall back to data file name: {row[0]!r} != {row[1]!r}"
 
 
 @pytest.mark.parametrize("change_extension", [True, False])


### PR DESCRIPTION
## Summary

`parse_sdrf convert-openms` crashed with `KeyError: 'comment[file uri]'` on SDRFs that lack that column.

`comment[file uri]` is an **optional** SDRF-Proteomics column — it is not in the REQUIRED columns and only appears (cardinality 1) in the multi-file-formats section for vendor sidecar formats (e.g. AB Sciex `.wiff`). 202 of 502 SDRFs in `bigbio/sdrf-annotated-datasets` have no such column and all crash on convert, even though `validate-sdrf` passes on the same files.

`openms_convert` read the column unconditionally:

```python
URI = row["comment[file uri]"]
```

## Change

Read the column with `.get(...)` and fall back to the required `comment[data file]` name when it is absent:

```python
URI = row.get("comment[file uri]", row["comment[data file]"])
```

This is the only unconditional access of `comment[file uri]` in the convert path. quantms only dereferences the URI when `--root_folder` is unset, so the file-name fallback is sufficient for the local-files case.

## Test

Adds a regression test (`test_convert_openms_without_file_uri`) that converts an SDRF with the `comment[file uri]` column removed and asserts the URI falls back to the data-file name. It fails before the fix (`KeyError`/`ValueError: Error: 'comment[file uri]'`) and passes after.

`uv run pytest tests/test_convert_openms.py` (39 passed) and `uv run pre-commit run` (ruff, ruff-format, mypy) are green.

Fixes #313