### PR TITLE
fix(validate-sdrf): honor multiple --template flags (#312)

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -36,16 +36,19 @@ Commands:
 ## Validate SDRF
 
 Command to validate the SDRF file. The validation is based on the template
-provided by the user. User can select the template to be used for
-validation. If no template is provided, the default template will be used.
-Additionally, the mass spectrometry fields and factor values can be
-validated separately. However, if the mass spectrometry validation or factor
-value validation is skipped, the user will be warned about it.
-@param sdrf_file: SDRF file to be validated @param template: template to be
-used for a validation @param use_ols_cache_only: flag to use the OLS cache
-for validation of the terms and not OLS internet service @param
-skip_ontology: flag to skip ontology term validation @param out: Output file
-to write the validation results to (default: stdout)
+provided by the user. User can select one or more templates to be used for
+validation. When several ``--template`` values are provided, the SDRF is
+validated against the union of all of them, so every template's required
+columns and value patterns are enforced in a single run. If no template is
+provided, the default template will be used. Additionally, the mass
+spectrometry fields and factor values can be validated separately. However,
+if the mass spectrometry validation or factor value validation is skipped,
+the user will be warned about it.
+@param sdrf_file: SDRF file to be validated @param templates: one or more
+templates to be used for validation @param use_ols_cache_only: flag to use
+the OLS cache for validation of the terms and not OLS internet service
+@param skip_ontology: flag to skip ontology term validation @param out:
+Output file to write the validation results to (default: stdout)
 
 ```bash
 parse_sdrf validate-sdrf [OPTIONS]
@@ -54,7 +57,7 @@ parse_sdrf validate-sdrf [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `-s, --sdrf_file TEXT` | SDRF file to be validated |
-| `-t, --template TEXT` | select the template that will be use to validate the file (default: ms-proteomics) |
+| `-t, --template TEXT` | Template(s) to validate the SDRF against (default: ms-proteomics). May be given multiple times; the SDRF is then validated against the union of all templates and every template's required columns and value patterns are enforced. |
 | `--use_ols_cache_only` | Use ols cache for validation of the terms and not OLS internet service |
 | `--skip-ontology` | Skip ontology term validation (useful when ontology dependencies are not installed) |
 | `-o, --out TEXT` | Output file to write the validation results to (default: stdout) |

--- a/src/sdrf_pipelines/parse_sdrf.py
+++ b/src/sdrf_pipelines/parse_sdrf.py
@@ -28,7 +28,7 @@ from sdrf_pipelines.ols.ols import (
 )
 from sdrf_pipelines.sdrf.schemas import SchemaRegistry, SchemaValidator
 from sdrf_pipelines.sdrf.sdrf import read_sdrf
-from sdrf_pipelines.utils.exceptions import AppConfigException
+from sdrf_pipelines.utils.exceptions import AppConfigException, LogicError
 from sdrf_pipelines.utils.utils import ValidationProof
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -183,8 +183,14 @@ def maxquant_from_sdrf(
 @click.option(
     "--template",
     "-t",
-    help="select the template that will be use to validate the file (default: ms-proteomics)",
-    default="ms-proteomics",
+    "templates",
+    help=(
+        "Template(s) to validate the SDRF against (default: ms-proteomics). "
+        "May be given multiple times; the SDRF is then validated against the union of all "
+        "templates and every template's required columns and value patterns are enforced."
+    ),
+    default=(),
+    multiple=True,
     required=False,
 )
 @click.option(
@@ -223,7 +229,7 @@ def maxquant_from_sdrf(
 def validate_sdrf(
     ctx,
     sdrf_file: str,
-    template: str,
+    templates: tuple[str, ...],
     use_ols_cache_only: bool,
     skip_ontology: bool,
     out: Optional[str] = None,
@@ -233,12 +239,14 @@ def validate_sdrf(
 ):
     """
     Command to validate the SDRF file. The validation is based on the template provided by the user.
-    User can select the template to be used for validation. If no template is provided, the default template will
+    User can select one or more templates to be used for validation. When several ``--template`` values are
+    provided, the SDRF is validated against the union of all of them, so every template's required columns and
+    value patterns are enforced in a single run. If no template is provided, the default template will
     be used. Additionally, the mass spectrometry fields and factor values can be validated separately. However, if
     the mass spectrometry validation or factor value validation is skipped, the user will be warned about it.
 
     @param sdrf_file: SDRF file to be validated
-    @param template: template to be used for a validation
+    @param templates: one or more templates to be used for validation
     @param use_ols_cache_only: flag to use the OLS cache for validation of the terms and not OLS internet service
     @param skip_ontology: flag to skip ontology term validation
     @param out: Output file to write the validation results to (default: stdout)
@@ -258,8 +266,8 @@ def validate_sdrf(
         logging.error(msg)
         raise AppConfigException(msg)
 
-    if template is None:
-        template = "ms-proteomics"
+    if not templates:
+        templates = ("ms-proteomics",)
 
     registry = SchemaRegistry()
     validator = SchemaValidator(registry)
@@ -267,19 +275,27 @@ def validate_sdrf(
     validation_proof = ValidationProof()
     template_content = ""
     if generate_proof:
-        try:
-            if hasattr(registry, "raw_schema_data") and template in registry.raw_schema_data:
-                template_content = yaml.dump(registry.raw_schema_data[template], sort_keys=True)
-            else:
-                schema_dir = os.path.join(os.path.dirname(__file__), "sdrf", "schemas")
-                template_file = os.path.join(schema_dir, f"{template}.yaml")
-                if os.path.exists(template_file):
-                    with open(template_file, "r", encoding="utf-8") as f:
-                        template_content = f.read()
-        except Exception as e:
-            logging.warning("Could not load template content for proof generation: %s", e)
+        contents = []
+        for template in templates:
+            try:
+                if hasattr(registry, "raw_schema_data") and template in registry.raw_schema_data:
+                    contents.append(yaml.dump(registry.raw_schema_data[template], sort_keys=True))
+                else:
+                    schema_dir = os.path.join(os.path.dirname(__file__), "sdrf", "schemas")
+                    template_file = os.path.join(schema_dir, f"{template}.yaml")
+                    if os.path.exists(template_file):
+                        with open(template_file, "r", encoding="utf-8") as f:
+                            contents.append(f.read())
+            except Exception as e:
+                logging.warning("Could not load template content for proof generation: %s", e)
+        template_content = "\n".join(contents)
 
-    errors = validator.validate(sdrf_df, template, use_ols_cache_only, skip_ontology=skip_ontology)
+    # Validate against every requested template and aggregate the errors so that all
+    # declared templates' rules are enforced (see issue #312). Duplicate errors shared
+    # across templates are removed later via the error DataFrame de-duplication.
+    errors: list[LogicError] = []
+    for template in templates:
+        errors.extend(validator.validate(sdrf_df, template, use_ols_cache_only, skip_ontology=skip_ontology))
     errors_not_warnings = [error for error in errors if error.error_type == logging.ERROR]
     error_list = []
     for error in errors:

--- a/src/sdrf_pipelines/parse_sdrf.py
+++ b/src/sdrf_pipelines/parse_sdrf.py
@@ -268,6 +268,10 @@ def validate_sdrf(
 
     if not templates:
         templates = ("ms-proteomics",)
+    # Normalize to a unique, deterministic order so repeating or reordering
+    # --template flags neither re-validates the same schema nor changes the
+    # order-independent proof hash (#317 review).
+    templates = tuple(sorted(set(templates)))
 
     registry = SchemaRegistry()
     validator = SchemaValidator(registry)

--- a/tests/test_sdrfchecker.py
+++ b/tests/test_sdrfchecker.py
@@ -83,3 +83,85 @@ def test_on_reference_sdrf(file_subpath, shared_datadir, on_tmpdir):
         or "Everything seems to be fine. Well done." in result.output
         or "Most seems to be fine. There were only warnings." in result.output
     )
+
+
+# ``comment[cleavage agent details]`` is required by ``ms-proteomics`` but not by
+# ``cell-lines`` (the two templates are siblings that both extend ``sample-metadata``).
+_SDRF_MISSING_MS_PROTEOMICS_COLUMN = (
+    "\t".join(
+        [
+            "source name",
+            "characteristics[organism]",
+            "characteristics[cell line]",
+            "characteristics[disease]",
+            "characteristics[cellosaurus accession]",
+            "assay name",
+            "comment[instrument]",
+            "comment[label]",
+            "comment[fraction identifier]",
+            "comment[proteomics data acquisition method]",
+        ]
+    )
+    + "\n"
+    + "\t".join(
+        [
+            "sample 1",
+            "Homo sapiens",
+            "HeLa",
+            "cervical cancer",
+            "CVCL_0030",
+            "run 1",
+            "NT=Orbitrap Fusion;AC=MS:1002416",
+            "label free sample",
+            "1",
+            "NT=Data-Dependent Acquisition;AC=NCIT:C161785",
+        ]
+    )
+    + "\n"
+)
+
+_MS_PROTEOMICS_ONLY_COLUMN = "Required column 'comment[cleavage agent details]'"
+
+
+def test_validate_sdrf_honors_multiple_templates(tmp_path):
+    """Regression test for issue #312.
+
+    Passing several ``--template`` flags used to silently drop all but the last value,
+    so a rule that only belongs to an earlier template was never enforced. With the
+    fix, the SDRF is validated against the union of every ``--template`` given, so the
+    ms-proteomics-only required column is reported even though it is not the last
+    template on the command line.
+    """
+    sdrf_file = tmp_path / "cell_lines_missing_ms_proteomics_column.sdrf.tsv"
+    sdrf_file.write_text(_SDRF_MISSING_MS_PROTEOMICS_COLUMN)
+
+    runner = CliRunner()
+
+    # Only the "last" template used to win: cell-lines does not require the column,
+    # so on its own it must not report it.
+    single = runner.invoke(
+        cli,
+        ["validate-sdrf", "--sdrf_file", str(sdrf_file), "-t", "cell-lines", "--skip-ontology"],
+        catch_exceptions=False,
+        standalone_mode=False,
+    )
+    assert _MS_PROTEOMICS_ONLY_COLUMN not in single.output, single.output
+
+    # With both templates, the ms-proteomics rule must be enforced even though
+    # cell-lines is given last.
+    multi = runner.invoke(
+        cli,
+        [
+            "validate-sdrf",
+            "--sdrf_file",
+            str(sdrf_file),
+            "-t",
+            "ms-proteomics",
+            "-t",
+            "cell-lines",
+            "--skip-ontology",
+        ],
+        catch_exceptions=False,
+        standalone_mode=False,
+    )
+    assert _MS_PROTEOMICS_ONLY_COLUMN in multi.output, multi.output

--- a/tests/test_sdrfchecker.py
+++ b/tests/test_sdrfchecker.py
@@ -145,6 +145,10 @@ def test_validate_sdrf_honors_multiple_templates(tmp_path):
         catch_exceptions=False,
         standalone_mode=False,
     )
+    # cell-lines alone does not require the ms-proteomics column, so it must not
+    # report it (the minimal synthetic SDRF may still fail cell-lines for other
+    # baseline reasons, so the targeted absence check — not exit code — is the
+    # reliable signal here).
     assert _MS_PROTEOMICS_ONLY_COLUMN not in single.output, single.output
 
     # With both templates, the ms-proteomics rule must be enforced even though
@@ -165,3 +169,6 @@ def test_validate_sdrf_honors_multiple_templates(tmp_path):
         standalone_mode=False,
     )
     assert _MS_PROTEOMICS_ONLY_COLUMN in multi.output, multi.output
+    # the missing ms-proteomics required column is a hard error, so the command
+    # must exit non-zero (sys.exit(bool(errors_not_warnings))).
+    assert multi.exit_code != 0, multi.output


### PR DESCRIPTION
## Problem

`parse_sdrf validate-sdrf` declared `--template` as a **single-value** click option, so passing several `--template` flags silently validated against **only the last one**. Every earlier template's required columns and value patterns were dropped with no warning.

This caused real validation gaps: a multi-template single-cell SDRF declaring `ms-proteomics + single-cell + dia-acquisition + cell-lines` never checked the `ms-proteomics` rules because only the last template ran.

## Fix (option 2 — union / merge)

- Make `--template` `multiple=True` (option name unchanged; destination renamed to `templates`).
- Validate the SDRF against the **union** of all given templates, aggregating the errors so every template's required columns and value patterns are enforced in one run. Duplicate errors shared across templates are removed by the existing error de-duplication.
- Backward compatible: a single `--template` behaves as before, and when none is given `ms-proteomics` is still the default.
- Proof generation now hashes the concatenation of all selected templates.
- Updated the `--template` `--help` text and regenerated `COMMANDS.md`.

## Test

Added `test_validate_sdrf_honors_multiple_templates` in `tests/test_sdrfchecker.py`. It validates an SDRF (missing the ms-proteomics-only required column `comment[cleavage agent details]`) with `-t ms-proteomics -t cell-lines` (cell-lines given last) and asserts the missing column is reported. The test **fails before** the fix (only `cell-lines` ran, which doesn't require that column) and **passes after**.

`uv run pre-commit run` (ruff, ruff-format, mypy, CLI-docs) passes on the changed files.

Fixes #312