### PR TITLE
Fix optional file URI handling and support multiple templates

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -36,16 +36,19 @@ Commands:
 ## Validate SDRF
 
 Command to validate the SDRF file. The validation is based on the template
-provided by the user. User can select the template to be used for
-validation. If no template is provided, the default template will be used.
-Additionally, the mass spectrometry fields and factor values can be
-validated separately. However, if the mass spectrometry validation or factor
-value validation is skipped, the user will be warned about it.
-@param sdrf_file: SDRF file to be validated @param template: template to be
-used for a validation @param use_ols_cache_only: flag to use the OLS cache
-for validation of the terms and not OLS internet service @param
-skip_ontology: flag to skip ontology term validation @param out: Output file
-to write the validation results to (default: stdout)
+provided by the user. User can select one or more templates to be used for
+validation. When several ``--template`` values are provided, the SDRF is
+validated against the union of all of them, so every template's required
+columns and value patterns are enforced in a single run. If no template is
+provided, the default template will be used. Additionally, the mass
+spectrometry fields and factor values can be validated separately. However,
+if the mass spectrometry validation or factor value validation is skipped,
+the user will be warned about it.
+@param sdrf_file: SDRF file to be validated @param templates: one or more
+templates to be used for validation @param use_ols_cache_only: flag to use
+the OLS cache for validation of the terms and not OLS internet service
+@param skip_ontology: flag to skip ontology term validation @param out:
+Output file to write the validation results to (default: stdout)
 
 ```bash
 parse_sdrf validate-sdrf [OPTIONS]
@@ -54,7 +57,7 @@ parse_sdrf validate-sdrf [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `-s, --sdrf_file TEXT` | SDRF file to be validated |
-| `-t, --template TEXT` | select the template that will be use to validate the file (default: ms-proteomics) |
+| `-t, --template TEXT` | Template(s) to validate the SDRF against (default: ms-proteomics). May be given multiple times; the SDRF is then validated against the union of all templates and every template's required columns and value patterns are enforced. |
 | `--use_ols_cache_only` | Use ols cache for validation of the terms and not OLS internet service |
 | `--skip-ontology` | Skip ontology term validation (useful when ontology dependencies are not installed) |
 | `-o, --out TEXT` | Output file to write the validation results to (default: stdout) |

--- a/src/sdrf_pipelines/converters/openms/openms.py
+++ b/src/sdrf_pipelines/converters/openms/openms.py
@@ -410,7 +410,9 @@ class OpenMS:
         raws = []
 
         for _, row in sdrf.iterrows():
-            URI = row["comment[file uri]"]
+            # comment[file uri] is optional in SDRF-Proteomics; fall back to the
+            # (required) data file name when the column is absent (see issue #313).
+            URI = row.get("comment[file uri]", row["comment[data file]"])
             raw = row["comment[data file]"]
 
             if "comment[proteomics data acquisition method]" not in row:

--- a/src/sdrf_pipelines/parse_sdrf.py
+++ b/src/sdrf_pipelines/parse_sdrf.py
@@ -28,7 +28,7 @@ from sdrf_pipelines.ols.ols import (
 )
 from sdrf_pipelines.sdrf.schemas import SchemaRegistry, SchemaValidator
 from sdrf_pipelines.sdrf.sdrf import read_sdrf
-from sdrf_pipelines.utils.exceptions import AppConfigException
+from sdrf_pipelines.utils.exceptions import AppConfigException, LogicError
 from sdrf_pipelines.utils.utils import ValidationProof
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
@@ -183,8 +183,14 @@ def maxquant_from_sdrf(
 @click.option(
     "--template",
     "-t",
-    help="select the template that will be use to validate the file (default: ms-proteomics)",
-    default="ms-proteomics",
+    "templates",
+    help=(
+        "Template(s) to validate the SDRF against (default: ms-proteomics). "
+        "May be given multiple times; the SDRF is then validated against the union of all "
+        "templates and every template's required columns and value patterns are enforced."
+    ),
+    default=(),
+    multiple=True,
     required=False,
 )
 @click.option(
@@ -223,7 +229,7 @@ def maxquant_from_sdrf(
 def validate_sdrf(
     ctx,
     sdrf_file: str,
-    template: str,
+    templates: tuple[str, ...],
     use_ols_cache_only: bool,
     skip_ontology: bool,
     out: Optional[str] = None,
@@ -233,12 +239,14 @@ def validate_sdrf(
 ):
     """
     Command to validate the SDRF file. The validation is based on the template provided by the user.
-    User can select the template to be used for validation. If no template is provided, the default template will
+    User can select one or more templates to be used for validation. When several ``--template`` values are
+    provided, the SDRF is validated against the union of all of them, so every template's required columns and
+    value patterns are enforced in a single run. If no template is provided, the default template will
     be used. Additionally, the mass spectrometry fields and factor values can be validated separately. However, if
     the mass spectrometry validation or factor value validation is skipped, the user will be warned about it.
 
     @param sdrf_file: SDRF file to be validated
-    @param template: template to be used for a validation
+    @param templates: one or more templates to be used for validation
     @param use_ols_cache_only: flag to use the OLS cache for validation of the terms and not OLS internet service
     @param skip_ontology: flag to skip ontology term validation
     @param out: Output file to write the validation results to (default: stdout)
@@ -258,8 +266,8 @@ def validate_sdrf(
         logging.error(msg)
         raise AppConfigException(msg)
 
-    if template is None:
-        template = "ms-proteomics"
+    if not templates:
+        templates = ("ms-proteomics",)
 
     registry = SchemaRegistry()
     validator = SchemaValidator(registry)
@@ -267,19 +275,27 @@ def validate_sdrf(
     validation_proof = ValidationProof()
     template_content = ""
     if generate_proof:
-        try:
-            if hasattr(registry, "raw_schema_data") and template in registry.raw_schema_data:
-                template_content = yaml.dump(registry.raw_schema_data[template], sort_keys=True)
-            else:
-                schema_dir = os.path.join(os.path.dirname(__file__), "sdrf", "schemas")
-                template_file = os.path.join(schema_dir, f"{template}.yaml")
-                if os.path.exists(template_file):
-                    with open(template_file, "r", encoding="utf-8") as f:
-                        template_content = f.read()
-        except Exception as e:
-            logging.warning("Could not load template content for proof generation: %s", e)
+        contents = []
+        for template in templates:
+            try:
+                if hasattr(registry, "raw_schema_data") and template in registry.raw_schema_data:
+                    contents.append(yaml.dump(registry.raw_schema_data[template], sort_keys=True))
+                else:
+                    schema_dir = os.path.join(os.path.dirname(__file__), "sdrf", "schemas")
+                    template_file = os.path.join(schema_dir, f"{template}.yaml")
+                    if os.path.exists(template_file):
+                        with open(template_file, "r", encoding="utf-8") as f:
+                            contents.append(f.read())
+            except Exception as e:
+                logging.warning("Could not load template content for proof generation: %s", e)
+        template_content = "\n".join(contents)
 
-    errors = validator.validate(sdrf_df, template, use_ols_cache_only, skip_ontology=skip_ontology)
+    # Validate against every requested template and aggregate the errors so that all
+    # declared templates' rules are enforced (see issue #312). Duplicate errors shared
+    # across templates are removed later via the error DataFrame de-duplication.
+    errors: list[LogicError] = []
+    for template in templates:
+        errors.extend(validator.validate(sdrf_df, template, use_ols_cache_only, skip_ontology=skip_ontology))
     errors_not_warnings = [error for error in errors if error.error_type == logging.ERROR]
     error_list = []
     for error in errors:

--- a/src/sdrf_pipelines/parse_sdrf.py
+++ b/src/sdrf_pipelines/parse_sdrf.py
@@ -268,6 +268,10 @@ def validate_sdrf(
 
     if not templates:
         templates = ("ms-proteomics",)
+    # Normalize to a unique, deterministic order so repeating or reordering
+    # --template flags neither re-validates the same schema nor changes the
+    # order-independent proof hash (#317 review).
+    templates = tuple(sorted(set(templates)))
 
     registry = SchemaRegistry()
     validator = SchemaValidator(registry)

--- a/tests/test_convert_openms.py
+++ b/tests/test_convert_openms.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from sdrf_pipelines.parse_sdrf import cli
@@ -53,6 +54,34 @@ def test_convert_openms(shared_datadir, on_tmpdir):
     result = run_and_check_status_code(cli, ["convert-openms", "-t2", "-s", test_sdrf])
     assert "ERROR" not in result.output.upper(), result.output
     _check_output_existance(on_tmpdir)
+
+
+def test_convert_openms_without_file_uri(shared_datadir, on_tmpdir):
+    """Regression test for issue #313.
+
+    ``comment[file uri]`` is optional in SDRF-Proteomics. ``convert-openms`` used to
+    read it unconditionally and crash with ``KeyError: 'comment[file uri]'`` on SDRFs
+    that do not have that column. Ensure conversion succeeds and the URI falls back to
+    the (required) data file name.
+    """
+    src_sdrf = shared_datadir / "PXD001819/PXD001819.sdrf.tsv"
+    df = pd.read_csv(src_sdrf, sep="\t", dtype=str)
+    assert "comment[file uri]" in df.columns, "fixture expected to have comment[file uri]"
+    df = df.drop(columns=["comment[file uri]"])
+
+    test_sdrf = shared_datadir / "PXD001819/PXD001819.no_file_uri.sdrf.tsv"
+    df.to_csv(test_sdrf, sep="\t", index=False)
+
+    result = run_and_check_status_code(cli, ["convert-openms", "-t2", "-s", test_sdrf])
+    assert "ERROR" not in result.output.upper(), result.output
+    _check_output_existance(on_tmpdir)
+
+    # URI (column 0) must fall back to the data file name (column 1).
+    with open(on_tmpdir / "openms.tsv", "r") as f:
+        rows = [line.rstrip("\n").split("\t") for line in f.readlines()[1:]]
+    assert rows, "openms.tsv has no data rows"
+    for row in rows:
+        assert row[0] == row[1], f"URI did not fall back to data file name: {row[0]!r} != {row[1]!r}"
 
 
 @pytest.mark.parametrize("change_extension", [True, False])

--- a/tests/test_convert_openms.py
+++ b/tests/test_convert_openms.py
@@ -69,7 +69,9 @@ def test_convert_openms_without_file_uri(shared_datadir, on_tmpdir):
     assert "comment[file uri]" in df.columns, "fixture expected to have comment[file uri]"
     df = df.drop(columns=["comment[file uri]"])
 
-    test_sdrf = shared_datadir / "PXD001819/PXD001819.no_file_uri.sdrf.tsv"
+    # Write the modified SDRF to the isolated tmp dir, not shared_datadir (which
+    # pytest-datadir shares across the session).
+    test_sdrf = on_tmpdir / "PXD001819.no_file_uri.sdrf.tsv"
     df.to_csv(test_sdrf, sep="\t", index=False)
 
     result = run_and_check_status_code(cli, ["convert-openms", "-t2", "-s", test_sdrf])

--- a/tests/test_sdrfchecker.py
+++ b/tests/test_sdrfchecker.py
@@ -83,3 +83,85 @@ def test_on_reference_sdrf(file_subpath, shared_datadir, on_tmpdir):
         or "Everything seems to be fine. Well done." in result.output
         or "Most seems to be fine. There were only warnings." in result.output
     )
+
+
+# ``comment[cleavage agent details]`` is required by ``ms-proteomics`` but not by
+# ``cell-lines`` (the two templates are siblings that both extend ``sample-metadata``).
+_SDRF_MISSING_MS_PROTEOMICS_COLUMN = (
+    "\t".join(
+        [
+            "source name",
+            "characteristics[organism]",
+            "characteristics[cell line]",
+            "characteristics[disease]",
+            "characteristics[cellosaurus accession]",
+            "assay name",
+            "comment[instrument]",
+            "comment[label]",
+            "comment[fraction identifier]",
+            "comment[proteomics data acquisition method]",
+        ]
+    )
+    + "\n"
+    + "\t".join(
+        [
+            "sample 1",
+            "Homo sapiens",
+            "HeLa",
+            "cervical cancer",
+            "CVCL_0030",
+            "run 1",
+            "NT=Orbitrap Fusion;AC=MS:1002416",
+            "label free sample",
+            "1",
+            "NT=Data-Dependent Acquisition;AC=NCIT:C161785",
+        ]
+    )
+    + "\n"
+)
+
+_MS_PROTEOMICS_ONLY_COLUMN = "Required column 'comment[cleavage agent details]'"
+
+
+def test_validate_sdrf_honors_multiple_templates(tmp_path):
+    """Regression test for issue #312.
+
+    Passing several ``--template`` flags used to silently drop all but the last value,
+    so a rule that only belongs to an earlier template was never enforced. With the
+    fix, the SDRF is validated against the union of every ``--template`` given, so the
+    ms-proteomics-only required column is reported even though it is not the last
+    template on the command line.
+    """
+    sdrf_file = tmp_path / "cell_lines_missing_ms_proteomics_column.sdrf.tsv"
+    sdrf_file.write_text(_SDRF_MISSING_MS_PROTEOMICS_COLUMN)
+
+    runner = CliRunner()
+
+    # Only the "last" template used to win: cell-lines does not require the column,
+    # so on its own it must not report it.
+    single = runner.invoke(
+        cli,
+        ["validate-sdrf", "--sdrf_file", str(sdrf_file), "-t", "cell-lines", "--skip-ontology"],
+        catch_exceptions=False,
+        standalone_mode=False,
+    )
+    assert _MS_PROTEOMICS_ONLY_COLUMN not in single.output, single.output
+
+    # With both templates, the ms-proteomics rule must be enforced even though
+    # cell-lines is given last.
+    multi = runner.invoke(
+        cli,
+        [
+            "validate-sdrf",
+            "--sdrf_file",
+            str(sdrf_file),
+            "-t",
+            "ms-proteomics",
+            "-t",
+            "cell-lines",
+            "--skip-ontology",
+        ],
+        catch_exceptions=False,
+        standalone_mode=False,
+    )
+    assert _MS_PROTEOMICS_ONLY_COLUMN in multi.output, multi.output

--- a/tests/test_sdrfchecker.py
+++ b/tests/test_sdrfchecker.py
@@ -145,6 +145,10 @@ def test_validate_sdrf_honors_multiple_templates(tmp_path):
         catch_exceptions=False,
         standalone_mode=False,
     )
+    # cell-lines alone does not require the ms-proteomics column, so it must not
+    # report it (the minimal synthetic SDRF may still fail cell-lines for other
+    # baseline reasons, so the targeted absence check — not exit code — is the
+    # reliable signal here).
     assert _MS_PROTEOMICS_ONLY_COLUMN not in single.output, single.output
 
     # With both templates, the ms-proteomics rule must be enforced even though
@@ -165,3 +169,6 @@ def test_validate_sdrf_honors_multiple_templates(tmp_path):
         standalone_mode=False,
     )
     assert _MS_PROTEOMICS_ONLY_COLUMN in multi.output, multi.output
+    # the missing ms-proteomics required column is a hard error, so the command
+    # must exit non-zero (sys.exit(bool(errors_not_warnings))).
+    assert multi.exit_code != 0, multi.output


### PR DESCRIPTION
This pull request enhances the SDRF validation command to support validating against multiple templates at once, ensuring all required columns and value patterns from all specified templates are enforced. It also improves robustness in the OpenMS converter by handling missing optional columns, and adds regression tests for these behaviors.

**SDRF Validation Improvements:**

* The `validate-sdrf` command now accepts multiple `--template` flags, validating the SDRF against the union of all provided templates so that every required column and value pattern from all templates is enforced. Duplicate errors are de-duplicated, and the template list is normalized for deterministic behavior. [[1]](diffhunk://#diff-ef6cbfac609924ae87b6c1d2fe84d979abb5f4a0bccec47fc99883592cd16844L39-R51) [[2]](diffhunk://#diff-ef6cbfac609924ae87b6c1d2fe84d979abb5f4a0bccec47fc99883592cd16844L57-R60) [[3]](diffhunk://#diff-89c68ae604fce1e374f5d2be4cf718a4ba2c4dc373daf3abd17173578b131b1cL186-R193) [[4]](diffhunk://#diff-89c68ae604fce1e374f5d2be4cf718a4ba2c4dc373daf3abd17173578b131b1cL226-R232) [[5]](diffhunk://#diff-89c68ae604fce1e374f5d2be4cf718a4ba2c4dc373daf3abd17173578b131b1cL236-R249) [[6]](diffhunk://#diff-89c68ae604fce1e374f5d2be4cf718a4ba2c4dc373daf3abd17173578b131b1cL261-R302)
* Documentation in `COMMANDS.md` and CLI help has been updated to reflect the new multiple-template behavior. [[1]](diffhunk://#diff-ef6cbfac609924ae87b6c1d2fe84d979abb5f4a0bccec47fc99883592cd16844L39-R51) [[2]](diffhunk://#diff-ef6cbfac609924ae87b6c1d2fe84d979abb5f4a0bccec47fc99883592cd16844L57-R60)

**OpenMS Converter Robustness:**

* The OpenMS converter now gracefully handles SDRFs missing the optional `comment[file uri]` column by falling back to the required `comment[data file]` column, preventing crashes on such input files.

**Testing Improvements:**

* Added a regression test to ensure that the OpenMS converter does not fail when `comment[file uri]` is missing and that it correctly falls back to the data file name.
* Added a regression test to verify that validation with multiple templates enforces all required columns from all templates, not just the last one specified.

**Internal Refactoring:**

* Minor import and typing updates to support new logic and error handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `validate-sdrf` now supports multiple `--template` options in one command, validating against the combined requirements of all selected templates.
  - The command defaults to the `ms-proteomics` template when none is specified.
- **Bug Fixes**
  - OpenMS conversion now works when the optional file URI column is absent, using the data file name instead.
  - Validation warnings clarify when mass-spectrometry or factor checks are skipped.
- **Documentation**
  - Updated command-line documentation to describe multiple-template validation and related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->