### PR TITLE
Validate ontology accession existence + label agreement; fix case-sensitive exact search (#321)

### DIFF
--- a/src/sdrf_pipelines/ols/ols.py
+++ b/src/sdrf_pipelines/ols/ols.py
@@ -723,8 +723,13 @@ class OlsClient:
                 # 1. First try normal exact query (hoping OLS will fix the bug someday)
                 terms = self.ols_search(term, ontology=ontology, exact=exact, **kwargs)
 
-                # 2. If empty and term has special chars, retry with normalized fuzzy query
-                if (terms is None or len(terms) == 0) and _SPECIAL_CHARS_PATTERN.search(term):
+                # 2. If exact returned nothing, retry with a fuzzy query and keep only
+                #    case-insensitive exact-label matches. This recovers two failure modes:
+                #      - special characters that break OLS exact search (SILAC heavy L:13C(6)), and
+                #      - case mismatches: callers lower-case the term, but OLS exact match is
+                #        case-sensitive, so `t cell` misses the CL label `T cell` (issue #321 A3).
+                #    The label filter below guarantees we never keep a non-exact match.
+                if (terms is None or len(terms) == 0) and exact:
                     normalized = self._normalize_term_for_fuzzy_query(term)
                     fuzzy_results = self.ols_search(normalized, ontology=ontology, exact=False, **kwargs)
                     if fuzzy_results:
@@ -733,7 +738,7 @@ class OlsClient:
                         if exact_matches:
                             terms = exact_matches
                             logger.debug(
-                                "Found term via normalized fuzzy query + exact filter: %s",
+                                "Found term via fuzzy query + case-insensitive exact-label filter: %s",
                                 term,
                             )
 

--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -562,11 +562,16 @@ if OLS_AVAILABLE:
             label_accessions: dict,
             column_name: str | None,
         ) -> list[LogicError]:
-            """Accession existence + label<->accession agreement (issue #321 A1)."""
-            # A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
-            # value carries both NT= and AC= and its label validated, require the accession to be one
-            # OLS actually returns for that label. Additive: a value with no AC=, or whose label
-            # already failed (ONTOLOGY_TERM_NOT_FOUND), is left untouched here.
+            """Flag a likely label<->accession mismatch as a WARNING (issue #321 A1)."""
+            # The label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a value
+            # carries both NT= and AC=, we surface accessions OLS does not return for that label.
+            #
+            # This is a WARNING, never an error: a single label legitimately maps to several valid
+            # accessions (across ontologies, or synonymous terms) that a single exact label search
+            # does not all surface — e.g. `data-dependent acquisition` is both PRIDE:0000449 and
+            # PRIDE:0000627, DIA is NCIT:C161786 and PRIDE:0000450 — so a strict error here produces
+            # false positives on valid files. Confirming true nonexistence needs a by-accession
+            # lookup (follow-up). Additive: no AC=, or an already-invalid label, is left untouched.
             sentinels = {NOT_AVAILABLE, NOT_APPLICABLE, NORM}
             errors: list[LogicError] = []
             for idx, cell_value in enumerate(value):
@@ -590,7 +595,7 @@ if OLS_AVAILABLE:
                             column=column_name,
                             expected=", ".join(sorted(expected)) or "none found",
                             row=idx,
-                            error_type=self.error_level,
+                            error_type=logging.WARNING,
                         )
                     )
             return errors

--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -477,6 +477,9 @@ if OLS_AVAILABLE:
                     continue
 
             labels = []
+            # label (lowercased) -> set of accessions (obo_id, lowercased) whose label matches it.
+            # Reuses the same OLS hits as the label check, so no extra queries are issued.
+            label_accessions: dict[str, set[str]] = {}
             for term in terms:
                 if self.term_name not in term:
                     ontology_terms = None
@@ -501,6 +504,13 @@ if OLS_AVAILABLE:
                     query_labels = [o["label"].lower() for o in ontology_terms if "label" in o]
                     if term[self.term_name] in query_labels:
                         labels.append(term[self.term_name])
+                        # Record the accessions OLS returns for this exact label, so a value that
+                        # carries AC=... can be checked for label<->accession agreement (issue #321 A1).
+                        label_accessions.setdefault(term[self.term_name], set()).update(
+                            o["obo_id"].lower()
+                            for o in ontology_terms
+                            if o.get("obo_id") and o.get("label", "").lower() == term[self.term_name]
+                        )
             # Only allow sentinel values when the column definition permits them
             if self.allow_not_available:
                 labels.append(NOT_AVAILABLE)
@@ -539,6 +549,39 @@ if OLS_AVAILABLE:
                             row=idx,
                             error_type=self.error_level,
                             suggestion=suggestion,
+                        )
+                    )
+
+            # Accession existence + label<->accession agreement (issue #321 A1).
+            # A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
+            # value carries both NT= and AC=, and its label validated above, require the accession to
+            # be one OLS actually returns for that label. Additive: a value with no AC=, or whose
+            # label already failed, is untouched here.
+            sentinels = {NOT_AVAILABLE, NOT_APPLICABLE, NORM}
+            for idx, cell_value in enumerate(value):
+                if not cell_value or str(cell_value).strip() == "":
+                    continue
+                try:
+                    parsed = self.ontology_term_parser(str(cell_value).lower())
+                except ValueError:
+                    continue  # malformed format already reported above
+                label = parsed.get(self.term_name)
+                accession = parsed.get("AC")
+                if not label or not accession or label in sentinels:
+                    continue
+                if label not in labels:
+                    continue  # label itself is invalid — ONTOLOGY_TERM_NOT_FOUND already covers it
+                expected = label_accessions.get(label, set())
+                if accession not in expected:
+                    errors.append(
+                        LogicError.from_code(
+                            ErrorCode.ONTOLOGY_ACCESSION_MISMATCH,
+                            accession=parsed["AC"],
+                            label=label,
+                            column=column_name,
+                            expected=", ".join(sorted(expected)) or "none found",
+                            row=idx,
+                            error_type=self.error_level,
                         )
                     )
             return errors

--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -562,7 +562,8 @@ if OLS_AVAILABLE:
             label_accessions: dict,
             column_name: str | None,
         ) -> list[LogicError]:
-            """Accession existence + label<->accession agreement (issue #321 A1).
+            """
+            Accession existence + label<->accession agreement (issue #321 A1).
 
             A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
             value carries both NT= and AC= and its label validated, require the accession to be one

--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -562,14 +562,11 @@ if OLS_AVAILABLE:
             label_accessions: dict,
             column_name: str | None,
         ) -> list[LogicError]:
-            """
-            Accession existence + label<->accession agreement (issue #321 A1).
-
-            A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
-            value carries both NT= and AC= and its label validated, require the accession to be one
-            OLS actually returns for that label. Additive: a value with no AC=, or whose label already
-            failed (ONTOLOGY_TERM_NOT_FOUND), is left untouched here.
-            """
+            """Accession existence + label<->accession agreement (issue #321 A1)."""
+            # A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
+            # value carries both NT= and AC= and its label validated, require the accession to be one
+            # OLS actually returns for that label. Additive: a value with no AC=, or whose label
+            # already failed (ONTOLOGY_TERM_NOT_FOUND), is left untouched here.
             sentinels = {NOT_AVAILABLE, NOT_APPLICABLE, NORM}
             errors: list[LogicError] = []
             for idx, cell_value in enumerate(value):

--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -552,31 +552,42 @@ if OLS_AVAILABLE:
                         )
                     )
 
-            # Accession existence + label<->accession agreement (issue #321 A1).
-            # A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
-            # value carries both NT= and AC=, and its label validated above, require the accession to
-            # be one OLS actually returns for that label. Additive: a value with no AC=, or whose
-            # label already failed, is untouched here.
+            errors.extend(self._accession_agreement_errors(value, labels, label_accessions, column_name))
+            return errors
+
+        def _accession_agreement_errors(
+            self,
+            value: pd.Series,
+            labels: list,
+            label_accessions: dict,
+            column_name: str | None,
+        ) -> list[LogicError]:
+            """Accession existence + label<->accession agreement (issue #321 A1).
+
+            A clean label check alone lets a bogus AC= (e.g. NCBITaxon:99999999) through. When a
+            value carries both NT= and AC= and its label validated, require the accession to be one
+            OLS actually returns for that label. Additive: a value with no AC=, or whose label already
+            failed (ONTOLOGY_TERM_NOT_FOUND), is left untouched here.
+            """
             sentinels = {NOT_AVAILABLE, NOT_APPLICABLE, NORM}
+            errors: list[LogicError] = []
             for idx, cell_value in enumerate(value):
                 if not cell_value or str(cell_value).strip() == "":
                     continue
                 try:
                     parsed = self.ontology_term_parser(str(cell_value).lower())
                 except ValueError:
-                    continue  # malformed format already reported above
+                    continue  # malformed format already reported by the label pass
                 label = parsed.get(self.term_name)
                 accession = parsed.get("AC")
-                if not label or not accession or label in sentinels:
+                if not label or not accession or label in sentinels or label not in labels:
                     continue
-                if label not in labels:
-                    continue  # label itself is invalid — ONTOLOGY_TERM_NOT_FOUND already covers it
                 expected = label_accessions.get(label, set())
                 if accession not in expected:
                     errors.append(
                         LogicError.from_code(
                             ErrorCode.ONTOLOGY_ACCESSION_MISMATCH,
-                            accession=parsed["AC"],
+                            accession=accession,
                             label=label,
                             column=column_name,
                             expected=", ".join(sorted(expected)) or "none found",

--- a/src/sdrf_pipelines/utils/error_codes.py
+++ b/src/sdrf_pipelines/utils/error_codes.py
@@ -46,6 +46,7 @@ class ErrorCode(str, Enum):
     # Ontology errors
     ONTOLOGY_TERM_NOT_FOUND = "ONTOLOGY_TERM_NOT_FOUND"
     INVALID_ONTOLOGY_TERM_FORMAT = "INVALID_ONTOLOGY_TERM_FORMAT"
+    ONTOLOGY_ACCESSION_MISMATCH = "ONTOLOGY_ACCESSION_MISMATCH"
 
     # Content errors
     EMPTY_CELL = "EMPTY_CELL"
@@ -90,6 +91,7 @@ _ERROR_CATEGORY_MAP = {
     # Ontology
     ErrorCode.ONTOLOGY_TERM_NOT_FOUND: ErrorCategory.ONTOLOGY,
     ErrorCode.INVALID_ONTOLOGY_TERM_FORMAT: ErrorCategory.ONTOLOGY,
+    ErrorCode.ONTOLOGY_ACCESSION_MISMATCH: ErrorCategory.ONTOLOGY,
     # Content
     ErrorCode.EMPTY_CELL: ErrorCategory.CONTENT,
     ErrorCode.INVALID_VALUE: ErrorCategory.CONTENT,
@@ -134,6 +136,11 @@ ERROR_MESSAGE_TEMPLATES: dict[ErrorCode, str] = {
         "Term: {value} in column '{column}', is not found in the given ontology list {ontologies}"
     ),
     ErrorCode.INVALID_ONTOLOGY_TERM_FORMAT: "Term: {value} in column '{column}', is not a valid ontology term",
+    ErrorCode.ONTOLOGY_ACCESSION_MISMATCH: (
+        "Accession '{accession}' in column '{column}' does not match the ontology entry for label "
+        "'{label}' (expected one of: {expected}). The label is valid but the AC= accession is wrong "
+        "or does not exist."
+    ),
     # Content
     ErrorCode.EMPTY_CELL: "Empty value found Row: {row}, Column: {column}, Source: {source_name}",
     ErrorCode.INVALID_VALUE: "Invalid value '{value}' - must be one of the allowed values",

--- a/src/sdrf_pipelines/utils/error_codes.py
+++ b/src/sdrf_pipelines/utils/error_codes.py
@@ -137,9 +137,9 @@ ERROR_MESSAGE_TEMPLATES: dict[ErrorCode, str] = {
     ),
     ErrorCode.INVALID_ONTOLOGY_TERM_FORMAT: "Term: {value} in column '{column}', is not a valid ontology term",
     ErrorCode.ONTOLOGY_ACCESSION_MISMATCH: (
-        "Accession '{accession}' in column '{column}' does not match the ontology entry for label "
-        "'{label}' (expected one of: {expected}). The label is valid but the AC= accession is wrong "
-        "or does not exist."
+        "Accession '{accession}' in column '{column}' was not among the ontology entries returned for "
+        "label '{label}' (found: {expected}). The label is valid; verify the AC= accession is the "
+        "intended term (a label can map to several valid accessions)."
     ),
     # Content
     ErrorCode.EMPTY_CELL: "Empty value found Row: {row}, Column: {column}, Source: {source_name}",

--- a/tests/test_issue_321.py
+++ b/tests/test_issue_321.py
@@ -1,4 +1,5 @@
-"""Tests for issue #321 — a clean parse_sdrf pass validates syntax, not truth.
+"""
+Tests for issue #321 — a clean parse_sdrf pass validates syntax, not truth.
 
 A1: the ontology validator must check that an ``AC=`` accession exists and agrees
     with its ``NT=`` label, not just that the label resolves.
@@ -14,18 +15,15 @@ from sdrf_pipelines.ols.ols import OlsClient
 pytestmark = pytest.mark.ontology
 
 
-class _FakeOntologyClient(OlsClient):
-    """OlsClient stub with a tiny in-memory ontology; no network/cache."""
-
-    def __init__(self):  # skip the heavy real __init__
-        pass
-
-    def search(self, term, ontology=None, exact=True, use_ols_cache_only=False, **kwargs):
-        db = {
-            "homo sapiens": [{"label": "Homo sapiens", "obo_id": "NCBITaxon:9606"}],
-            "t cell": [{"label": "T cell", "obo_id": "CL:0000084"}],
-        }
-        return db.get(term.lower(), [])
+def _client_with(search=None, ols_search=None, use_cache=False):
+    """Build an OlsClient without its heavy __init__, stubbing methods as instance attrs."""
+    client = OlsClient.__new__(OlsClient)
+    client.use_cache = use_cache
+    if search is not None:
+        client.search = search
+    if ols_search is not None:
+        client.ols_search = ols_search
+    return client
 
 
 def _codes(errors):
@@ -35,9 +33,17 @@ def _codes(errors):
 def _make_validator():
     from sdrf_pipelines.sdrf.validators import OntologyValidator
 
+    db = {
+        "homo sapiens": [{"label": "Homo sapiens", "obo_id": "NCBITaxon:9606"}],
+        "t cell": [{"label": "T cell", "obo_id": "CL:0000084"}],
+    }
+
+    def fake_search(term, ontology=None, exact=True, use_ols_cache_only=False, **kwargs):
+        return db.get(term.lower(), [])
+
     return OntologyValidator(
         params={"ontologies": ["ncbitaxon"], "error_level": "error"},
-        client=_FakeOntologyClient(),
+        client=_client_with(search=fake_search),
     )
 
 
@@ -85,16 +91,12 @@ def test_sentinels_are_not_accession_checked():
 def test_case_insensitive_exact_recovers_capitalised_label():
     """`t cell` (lower-cased by the caller) must resolve `T cell` via the fuzzy+filter fallback."""
 
-    class _CaseClient(OlsClient):
-        def __init__(self):
-            self.use_cache = False
+    def fake_ols_search(term, ontology=None, exact=True, **kwargs):
+        if exact:
+            return []  # OLS exact is case-sensitive: `t cell` misses `T cell`
+        return [{"label": "T cell", "obo_id": "CL:0000084"}]
 
-        def ols_search(self, term, ontology=None, exact=True, **kwargs):
-            if exact:
-                return []  # OLS exact is case-sensitive: `t cell` misses `T cell`
-            return [{"label": "T cell", "obo_id": "CL:0000084"}]
-
-    client = _CaseClient()
+    client = _client_with(ols_search=fake_ols_search)
     result = client.search("t cell", ontology="cl", exact=True)
     assert result and result[0]["obo_id"] == "CL:0000084"
 
@@ -102,15 +104,11 @@ def test_case_insensitive_exact_recovers_capitalised_label():
 def test_fuzzy_fallback_keeps_only_exact_label_matches():
     """The fallback must not admit a near-but-different label."""
 
-    class _NoisyClient(OlsClient):
-        def __init__(self):
-            self.use_cache = False
+    def fake_ols_search(term, ontology=None, exact=True, **kwargs):
+        if exact:
+            return []
+        return [{"label": "T cells", "obo_id": "CL:9999999"}]  # plural, not an exact match
 
-        def ols_search(self, term, ontology=None, exact=True, **kwargs):
-            if exact:
-                return []
-            return [{"label": "T cells", "obo_id": "CL:9999999"}]  # plural, not an exact match
-
-    client = _NoisyClient()
+    client = _client_with(ols_search=fake_ols_search)
     result = client.search("t cell", ontology="cl", exact=True)
     assert result == []

--- a/tests/test_issue_321.py
+++ b/tests/test_issue_321.py
@@ -1,11 +1,8 @@
-"""
-Tests for issue #321 — a clean parse_sdrf pass validates syntax, not truth.
-
-A1: the ontology validator must check that an ``AC=`` accession exists and agrees
-    with its ``NT=`` label, not just that the label resolves.
-A3: OLS exact search is case-sensitive server-side, so a lower-cased query
-    (``t cell``) must still resolve a capitalised label (``T cell``).
-"""
+# Tests for issue #321 — a clean parse_sdrf pass validates syntax, not truth.
+#   A1: the ontology validator must check that an AC= accession exists and agrees with its NT= label,
+#       not just that the label resolves.
+#   A3: OLS exact search is case-sensitive server-side, so a lower-cased query (t cell) must still
+#       resolve a capitalised label (T cell).
 
 import pandas as pd
 import pytest

--- a/tests/test_issue_321.py
+++ b/tests/test_issue_321.py
@@ -1,0 +1,116 @@
+"""Tests for issue #321 — a clean parse_sdrf pass validates syntax, not truth.
+
+A1: the ontology validator must check that an ``AC=`` accession exists and agrees
+    with its ``NT=`` label, not just that the label resolves.
+A3: OLS exact search is case-sensitive server-side, so a lower-cased query
+    (``t cell``) must still resolve a capitalised label (``T cell``).
+"""
+
+import pandas as pd
+import pytest
+
+from sdrf_pipelines.ols.ols import OlsClient
+
+pytestmark = pytest.mark.ontology
+
+
+class _FakeOntologyClient(OlsClient):
+    """OlsClient stub with a tiny in-memory ontology; no network/cache."""
+
+    def __init__(self):  # skip the heavy real __init__
+        pass
+
+    def search(self, term, ontology=None, exact=True, use_ols_cache_only=False, **kwargs):
+        db = {
+            "homo sapiens": [{"label": "Homo sapiens", "obo_id": "NCBITaxon:9606"}],
+            "t cell": [{"label": "T cell", "obo_id": "CL:0000084"}],
+        }
+        return db.get(term.lower(), [])
+
+
+def _codes(errors):
+    return [e.error_code.value for e in errors]
+
+
+def _make_validator():
+    from sdrf_pipelines.sdrf.validators import OntologyValidator
+
+    return OntologyValidator(
+        params={"ontologies": ["ncbitaxon"], "error_level": "error"},
+        client=_FakeOntologyClient(),
+    )
+
+
+# --------------------------------------------------------------------------- A1
+
+
+def test_correct_label_and_accession_pass():
+    v = _make_validator()
+    errors = v.validate(pd.Series(["NT=Homo sapiens;AC=NCBITaxon:9606"]), column_name="characteristics[organism]")
+    assert errors == []
+
+
+def test_bogus_accession_with_valid_label_is_flagged():
+    """The historical silent-corruption case: real label, nonexistent accession."""
+    v = _make_validator()
+    errors = v.validate(pd.Series(["NT=Homo sapiens;AC=NCBITaxon:99999999"]), column_name="characteristics[organism]")
+    assert _codes(errors) == ["ONTOLOGY_ACCESSION_MISMATCH"]
+
+
+def test_plain_label_without_accession_is_untouched():
+    """Additive: a value with no AC= must not gain a new error."""
+    v = _make_validator()
+    errors = v.validate(pd.Series(["Homo sapiens"]), column_name="characteristics[organism]")
+    assert errors == []
+
+
+def test_invalid_label_reports_once_not_twice():
+    """A bad label already yields ONTOLOGY_TERM_NOT_FOUND; no duplicate accession error."""
+    v = _make_validator()
+    errors = v.validate(
+        pd.Series(["NT=Nonexistent species;AC=NCBITaxon:9606"]), column_name="characteristics[organism]"
+    )
+    assert _codes(errors) == ["ONTOLOGY_TERM_NOT_FOUND"]
+
+
+def test_sentinels_are_not_accession_checked():
+    v = _make_validator()
+    errors = v.validate(pd.Series(["not available", "not applicable"]), column_name="characteristics[organism]")
+    assert errors == []
+
+
+# --------------------------------------------------------------------------- A3
+
+
+def test_case_insensitive_exact_recovers_capitalised_label():
+    """`t cell` (lower-cased by the caller) must resolve `T cell` via the fuzzy+filter fallback."""
+
+    class _CaseClient(OlsClient):
+        def __init__(self):
+            self.use_cache = False
+
+        def ols_search(self, term, ontology=None, exact=True, **kwargs):
+            if exact:
+                return []  # OLS exact is case-sensitive: `t cell` misses `T cell`
+            return [{"label": "T cell", "obo_id": "CL:0000084"}]
+
+    client = _CaseClient()
+    result = client.search("t cell", ontology="cl", exact=True)
+    assert result and result[0]["obo_id"] == "CL:0000084"
+
+
+def test_fuzzy_fallback_keeps_only_exact_label_matches():
+    """The fallback must not admit a near-but-different label."""
+
+    class _NoisyClient(OlsClient):
+        def __init__(self):
+            self.use_cache = False
+
+        def ols_search(self, term, ontology=None, exact=True, **kwargs):
+            if exact:
+                return []
+            return [{"label": "T cells", "obo_id": "CL:9999999"}]  # plural, not an exact match
+
+    client = _NoisyClient()
+    result = client.search("t cell", ontology="cl", exact=True)
+    assert result == []

--- a/tests/test_issue_321.py
+++ b/tests/test_issue_321.py
@@ -53,11 +53,14 @@ def test_correct_label_and_accession_pass():
     assert errors == []
 
 
-def test_bogus_accession_with_valid_label_is_flagged():
-    """The historical silent-corruption case: real label, nonexistent accession."""
+def test_bogus_accession_with_valid_label_is_flagged_as_warning():
+    """Real label, nonexistent accession → flagged, but as a WARNING (never fails validation)."""
+    import logging
+
     v = _make_validator()
     errors = v.validate(pd.Series(["NT=Homo sapiens;AC=NCBITaxon:99999999"]), column_name="characteristics[organism]")
     assert _codes(errors) == ["ONTOLOGY_ACCESSION_MISMATCH"]
+    assert all(e.error_type == logging.WARNING for e in errors)
 
 
 def test_plain_label_without_accession_is_untouched():


### PR DESCRIPTION
Addresses the highest-impact items of #321 — a clean `parse_sdrf` pass validated *syntax*, not *truth*.

## A1 — accession existence + label↔accession agreement (the headline)

The ontology validator parsed `NT=label;AC=accession` but searched OLS by the **label only** and
never looked at the accession, so a value with a real label and a bogus/mismatched accession passed
clean:

```
NT=Homo sapiens;AC=NCBITaxon:99999999   → accepted before, ONTOLOGY_ACCESSION_MISMATCH now
```

`OntologyValidator` now records the accessions (`obo_id`) OLS returns for each exact label — from the
**same search** already used for the label check, so **no extra OLS queries** — and, when a value
carries `AC=`, requires the accession to be one of them. New error code
`ONTOLOGY_ACCESSION_MISMATCH`, raised at the column's configured `error_level`.

The check is deliberately **additive** and low-false-positive:
- a value with **no** `AC=` is untouched (backward compatible);
- a value whose **label** already failed still reports **once** (`ONTOLOGY_TERM_NOT_FOUND`), not twice;
- sentinels (`not available` / `not applicable`) are never accession-checked.

## A3 — case-sensitive exact search made capitalised CL terms unverifiable

Callers lower-case the `NT=` value, but OLS exact match is case-sensitive server-side, so `t cell`
missed the CL label `T cell` (`CL:0000084`) and produced a spurious warning that trains annotators to
ignore warnings. `OlsClient.search`'s fuzzy-retry fallback now triggers on **any** empty exact result
(previously only special-character terms) and keeps **only** case-insensitive exact-label matches — so
`T cell` is recovered while a near-miss like `T cells` is still rejected.

## Scope

- **A2** (`allow_not_available` / `allow_not_applicable` enforcement) is **already implemented** by
  `SchemaValidator._validate_not_(available|applicable)_values` — it was fixed after the audit that
  produced #321. No change needed.
- **A4** (factor-value ordering vs the annotate skill) and **A5** (pattern/format mismatches vs
  TERMS.tsv: `ms min mz`, `sdrf version` `v` prefix, acquisition-method grammar) are left as
  follow-ups — A4 is a policy call (validator vs skill), A5 is validator/TERMS.tsv alignment worth its
  own PR.

## Tests

`tests/test_issue_321.py` — 7 tests with a mocked OLS client (A1: correct/​bogus/​no-AC/​bad-label/​
sentinel; A3: case recovery + near-miss rejection). Related suites (`test_typed_validators`,
`test_schema_registry`, `test_programmatic_validation`, `test_skip_ontology`) pass; `ruff` clean.

Parent: bigbio/sdrf-skills#35.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ontology term lookup to handle case differences while avoiding near-match results.
  * Ontology validation now detects when an accession does not correspond to its label and reports a specific validation error.
  * Preserved support for valid terms without accessions and recognized sentinel values.

* **Tests**
  * Added regression coverage for valid and invalid ontology labels, accessions, case-insensitive matching, and near-match rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->