### PR TITLE
Fix source names ending in the same 'sample N' collapsing to one Sample (#320)

### DIFF
--- a/src/sdrf_pipelines/converters/openms/experimental_design.py
+++ b/src/sdrf_pipelines/converters/openms/experimental_design.py
@@ -15,8 +15,11 @@ from sdrf_pipelines.converters.openms.constants import (
 from sdrf_pipelines.converters.openms.utils import get_openms_file_name, infer_itraqplex, infer_tmtplex
 from sdrf_pipelines.utils.utils import tsv_line
 
-# Pattern to extract sample number from source name
-SAMPLE_IDENTIFIER_RE = re.compile(r"sample (\d+)$", re.IGNORECASE)
+# Pattern for a source name that is *exactly* "sample N" (the canonical corpus).
+# Matched with fullmatch, not search: a suffix match (`.search` + `$`) would let two
+# different names ending in the same "sample N" — e.g. "Tumor sample 1" and
+# "Normal sample 1" — collapse into one Sample/BioReplicate (issue #320).
+SAMPLE_IDENTIFIER_RE = re.compile(r"sample (\d+)", re.IGNORECASE)
 
 
 @dataclass
@@ -61,7 +64,7 @@ class SampleIdTracker:
 
     def get_sample_info(self, source_name: str) -> tuple[str | int, str]:
         """Get sample ID and bio replicate string for a source name."""
-        sample_match = SAMPLE_IDENTIFIER_RE.search(source_name)
+        sample_match = SAMPLE_IDENTIFIER_RE.fullmatch(source_name.strip())
 
         if sample_match is not None:
             sample: str | int = sample_match.group(1)

--- a/tests/test_convert_openms.py
+++ b/tests/test_convert_openms.py
@@ -178,13 +178,11 @@ def test_on_reference_sdrf(file_subpath, two_files, shared_datadir, on_tmpdir):
     _check_output_existance(on_tmpdir, two_files=two_files)
 
 
+# Regression tests for issue #320: source names that merely *end* in the same 'sample N' must not
+# collapse into one OpenMS Sample / MSstats BioReplicate. Only a name that is exactly 'sample N'
+# takes the numeric shortcut; every other name gets a distinct per-name id.
 class TestSampleIdTrackerSuffixCollapse:
-    """Regression tests for issue #320.
-
-    Source names that merely *end* in the same 'sample N' must not collapse into one
-    OpenMS Sample / MSstats BioReplicate. Only a name that is exactly 'sample N' takes
-    the numeric shortcut; every other name gets a distinct per-name id.
-    """
+    """Regression tests for the issue #320 suffix-collapse bug."""
 
     def test_distinct_names_sharing_a_suffix_do_not_merge(self):
         from sdrf_pipelines.converters.openms.experimental_design import SampleIdTracker

--- a/tests/test_convert_openms.py
+++ b/tests/test_convert_openms.py
@@ -176,3 +176,41 @@ def test_on_reference_sdrf(file_subpath, two_files, shared_datadir, on_tmpdir):
     result = run_and_check_status_code(cli, cmd + ["-s", str(test_sdrf)])
     assert "ERROR" not in result.output.upper(), result.output
     _check_output_existance(on_tmpdir, two_files=two_files)
+
+
+class TestSampleIdTrackerSuffixCollapse:
+    """Regression tests for issue #320.
+
+    Source names that merely *end* in the same 'sample N' must not collapse into one
+    OpenMS Sample / MSstats BioReplicate. Only a name that is exactly 'sample N' takes
+    the numeric shortcut; every other name gets a distinct per-name id.
+    """
+
+    def test_distinct_names_sharing_a_suffix_do_not_merge(self):
+        from sdrf_pipelines.converters.openms.experimental_design import SampleIdTracker
+
+        tracker = SampleIdTracker()
+        results = {
+            name: tracker.get_sample_info(name)
+            for name in ["Tumor sample 1", "Normal sample 1", "Tumor sample 2", "Normal sample 2"]
+        }
+        samples = [sample for sample, _bio in results.values()]
+        assert len(set(samples)) == 4, f"names collapsed: {results}"
+
+    def test_canonical_sample_n_still_uses_numeric_shortcut(self):
+        from sdrf_pipelines.converters.openms.experimental_design import SampleIdTracker
+
+        tracker = SampleIdTracker()
+        assert tracker.get_sample_info("Sample 1") == ("1", "1")
+        assert tracker.get_sample_info("Sample 2") == ("2", "2")
+        # the same source name maps back to the same sample
+        assert tracker.get_sample_info("Sample 1") == ("1", "1")
+
+    def test_repeated_distinct_name_is_stable(self):
+        from sdrf_pipelines.converters.openms.experimental_design import SampleIdTracker
+
+        tracker = SampleIdTracker()
+        first = tracker.get_sample_info("Tumor sample 1")
+        # an unrelated name in between must not disturb the mapping
+        tracker.get_sample_info("Normal sample 1")
+        assert tracker.get_sample_info("Tumor sample 1") == first


### PR DESCRIPTION
Fixes #320.

## The bug

`SampleIdTracker` derived the OpenMS `Sample` (and MSstats `BioReplicate`) from a **suffix** match on
`source name`:

```python
SAMPLE_IDENTIFIER_RE = re.compile(r"sample (\d+)$", re.IGNORECASE)
sample_match = SAMPLE_IDENTIFIER_RE.search(source_name)   # <- matches the tail
```

So two different names ending in the same `sample N` collapsed into one sample, silently:

```
Tumor sample 1   -> Sample 1
Normal sample 1  -> Sample 1   # merged with the tumour
```

That value is an aggregation key downstream — OpenMS `PeptideAndProteinQuant` sums abundances per
`Sample`, and the same tracker feeds MSstats `BioReplicate` — so a natural paired design
(`Tumor sample 1` / `Normal sample 1`) was summed into one quantity.

## The fix

`.search()` → `.fullmatch()` (per the issue's suggestion): the numeric shortcut now applies only when
the **whole** name is exactly `sample N`; every other name falls through to the existing per-name
running id, so distinct names stay distinct.

```
Tumor sample 1  -> 1 ,  Normal sample 1 -> 2 ,  Tumor sample 2 -> 3 ,  Normal sample 2 -> 4
```

The canonical `Sample 1 … Sample N` corpus is unchanged — verified against the **PXD001819**
end-to-end `expected_experimental_design.tsv` (its source names are exactly `Sample 1..9`).

## Tests

3 regression tests in `tests/test_convert_openms.py` (suffix names stay distinct; canonical shortcut
preserved; repeated distinct name is stable). Full `test_convert_openms.py` + `test_converters_base.py`
pass (73); ruff clean.

## Notes / out of scope

- `converters/base.py` has a **parallel** `SAMPLE_IDENTIFIER_PATTERN` with the same `.search`+`$`
  shape, but its behaviour is explicitly pinned by tests (`"My Sample 42"` is asserted to match), so I
  left it untouched — happy to align it in a follow-up if that suffix behaviour is not intended.
- The numeric shortcut returns the label's number (a `str`) while the fallback returns an `int`
  running id — a pre-existing detail. In a file that *mixes* canonical `Sample N` and prefixed
  `X sample N` names the two id spaces could in principle overlap; unifying them is a separate concern
  from this collapse fix.
