### PR TITLE
Key OpenMS sample id on the source name column; drop the 'sample N' regex (#320 follow-up)

### DIFF
--- a/src/sdrf_pipelines/converters/openms/experimental_design.py
+++ b/src/sdrf_pipelines/converters/openms/experimental_design.py
@@ -1,6 +1,5 @@
 """Experimental design file writers for OpenMS conversion."""
 
-import re
 from dataclasses import dataclass, field
 
 import pandas as pd
@@ -14,12 +13,6 @@ from sdrf_pipelines.converters.openms.constants import (
 )
 from sdrf_pipelines.converters.openms.utils import get_openms_file_name, infer_itraqplex, infer_tmtplex
 from sdrf_pipelines.utils.utils import tsv_line
-
-# Pattern for a source name that is *exactly* "sample N" (the canonical corpus).
-# Matched with fullmatch, not search: a suffix match (`.search` + `$`) would let two
-# different names ending in the same "sample N" — e.g. "Tumor sample 1" and
-# "Normal sample 1" — collapse into one Sample/BioReplicate (issue #320).
-SAMPLE_IDENTIFIER_RE = re.compile(r"sample (\d+)", re.IGNORECASE)
 
 
 @dataclass
@@ -63,19 +56,14 @@ class SampleIdTracker:
     warnings: dict[str, int] = field(default_factory=dict)
 
     def get_sample_info(self, source_name: str) -> tuple[str | int, str]:
-        """Get sample ID and bio replicate string for a source name."""
-        sample_match = SAMPLE_IDENTIFIER_RE.fullmatch(source_name.strip())
-
-        if sample_match is not None:
-            sample: str | int = sample_match.group(1)
-            self._track_bio_replicate(sample)
-            bio_replicate = str(sample)
-        else:
-            self._add_warning("No sample number identifier")
-            sample = self._get_or_assign_id(source_name)
-            self._track_bio_replicate(sample)
-            bio_replicate = str(self.bio_replicates.index(sample) + 1)
-
+        """Assign a sample ID + bio replicate keyed on the source name."""
+        # `source name` is the SDRF column that is mandatory and unique per biological sample, so it
+        # *is* the sample identity: each distinct source name gets its own running id. This replaces
+        # the earlier "sample N" suffix heuristic, which both ignored the authoritative column and
+        # collapsed distinct names that merely ended in the same number (issue #320).
+        sample = self._get_or_assign_id(source_name)
+        self._track_bio_replicate(sample)
+        bio_replicate = str(self.bio_replicates.index(sample) + 1)
         return sample, bio_replicate
 
     def _get_or_assign_id(self, source_name: str) -> int:

--- a/src/sdrf_pipelines/converters/openms/experimental_design.py
+++ b/src/sdrf_pipelines/converters/openms/experimental_design.py
@@ -51,20 +51,17 @@ class SampleIdTracker:
     """Tracks sample ID assignments for source names."""
 
     sample_id_map: dict[str, int] = field(default_factory=dict)
-    bio_replicates: list[str | int] = field(default_factory=list)
     next_id: int = 1
     warnings: dict[str, int] = field(default_factory=dict)
 
     def get_sample_info(self, source_name: str) -> tuple[str | int, str]:
         """Assign a sample ID + bio replicate keyed on the source name."""
         # `source name` is the SDRF column that is mandatory and unique per biological sample, so it
-        # *is* the sample identity: each distinct source name gets its own running id. This replaces
-        # the earlier "sample N" suffix heuristic, which both ignored the authoritative column and
-        # collapsed distinct names that merely ended in the same number (issue #320).
+        # *is* the sample identity: each distinct source name gets its own running id (issue #320,
+        # replacing the "sample N" suffix heuristic). Ids are assigned sequentially in order of first
+        # appearance, so the id already equals the biological-replicate number.
         sample = self._get_or_assign_id(source_name)
-        self._track_bio_replicate(sample)
-        bio_replicate = str(self.bio_replicates.index(sample) + 1)
-        return sample, bio_replicate
+        return sample, str(sample)
 
     def _get_or_assign_id(self, source_name: str) -> int:
         """Get existing or assign new sample ID for source name."""
@@ -72,11 +69,6 @@ class SampleIdTracker:
             self.sample_id_map[source_name] = self.next_id
             self.next_id += 1
         return self.sample_id_map[source_name]
-
-    def _track_bio_replicate(self, sample: str | int) -> None:
-        """Track sample in bio replicates list if not already present."""
-        if sample not in self.bio_replicates:
-            self.bio_replicates.append(sample)
 
     def _add_warning(self, message: str) -> None:
         """Add a warning message."""
@@ -241,7 +233,7 @@ class ExperimentalDesignWriter:
 
         for _, row in sdrf.iterrows():
             raw = row["comment[data file]"]
-            source_name = row["source name"]
+            source_name = str(row["source name"]).strip()
             replicate = file2technical_rep[raw]
 
             fraction_group = self._calculate_fraction_group(
@@ -277,7 +269,7 @@ class ExperimentalDesignWriter:
 
         for _, row in sdrf.iterrows():
             raw = row["comment[data file]"]
-            source_name = row["source name"]
+            source_name = str(row["source name"]).strip()
             sample, bio_replicate = sample_tracker.get_sample_info(source_name)
             condition = self._get_condition(file2combined_factors, raw, row["comment[label]"], source_name)
 
@@ -325,7 +317,7 @@ class ExperimentalDesignWriter:
 
         for _, row in sdrf.iterrows():
             raw = row["comment[data file]"]
-            source_name = row["source name"]
+            source_name = str(row["source name"]).strip()
             replicate = file2technical_rep[raw]
 
             fraction_group = self._calculate_fraction_group(

--- a/src/sdrf_pipelines/converters/openms/openms.py
+++ b/src/sdrf_pipelines/converters/openms/openms.py
@@ -113,7 +113,7 @@ class OpenMS:
 
         for _, row in sdrf.iterrows():
             raw = row["comment[data file]"]
-            source_name = row["source name"]
+            source_name = str(row["source name"]).strip()
 
             # Extract modifications
             all_mods = list(row[mod_cols])

--- a/tests/test_convert_openms.py
+++ b/tests/test_convert_openms.py
@@ -178,9 +178,9 @@ def test_on_reference_sdrf(file_subpath, two_files, shared_datadir, on_tmpdir):
     _check_output_existance(on_tmpdir, two_files=two_files)
 
 
-# Regression tests for issue #320: source names that merely *end* in the same 'sample N' must not
-# collapse into one OpenMS Sample / MSstats BioReplicate. Only a name that is exactly 'sample N'
-# takes the numeric shortcut; every other name gets a distinct per-name id.
+# Regression tests for issue #320: the sample id is keyed on `source name` (the mandatory,
+# unique-per-sample SDRF column), so distinct names never collapse — including names that merely
+# end in the same number (the old "sample N" suffix heuristic collapsed those).
 class TestSampleIdTrackerSuffixCollapse:
     """Regression tests for the issue #320 suffix-collapse bug."""
 
@@ -195,14 +195,14 @@ class TestSampleIdTrackerSuffixCollapse:
         samples = [sample for sample, _bio in results.values()]
         assert len(set(samples)) == 4, f"names collapsed: {results}"
 
-    def test_canonical_sample_n_still_uses_numeric_shortcut(self):
+    def test_distinct_source_names_get_running_ids(self):
         from sdrf_pipelines.converters.openms.experimental_design import SampleIdTracker
 
         tracker = SampleIdTracker()
-        assert tracker.get_sample_info("Sample 1") == ("1", "1")
-        assert tracker.get_sample_info("Sample 2") == ("2", "2")
+        assert tracker.get_sample_info("Sample 1") == (1, "1")
+        assert tracker.get_sample_info("Sample 2") == (2, "2")
         # the same source name maps back to the same sample
-        assert tracker.get_sample_info("Sample 1") == ("1", "1")
+        assert tracker.get_sample_info("Sample 1") == (1, "1")
 
     def test_repeated_distinct_name_is_stable(self):
         from sdrf_pipelines.converters.openms.experimental_design import SampleIdTracker


### PR DESCRIPTION
Follow-up to #323, addressing @jpfeuffer's review: *"Why not first try to find a sample name column?
Isn't that a mandatory part of most sdrf templates?"*

Right — and `base.yaml` says it explicitly: **"`source name` must be unique per biological sample
across the entire SDRF file."** So `source name` *is* the mandatory, unique sample identifier, and the
`SampleIdTracker` should key on it directly.

This drops the `sample N` regex entirely and assigns each distinct `source name` its own running id.
The regex was both the source of the collapse bug (#320 — two names ending in the same number merged)
and redundant: real deposits never matched it anyway (their names look like `PDC000126-Sample-1`, not
`Sample 1`), so they already went through the source-name fallback.

**No behaviour change for the canonical `Sample 1..N` corpus** — verified against the PXD001819
end-to-end `expected_experimental_design.tsv` (all 42 openms conversion tests pass); `Sample 1..N` in
row order still enumerate to `1..N`.

Net −12 lines. Tests: `test_convert_openms.py` (42), `test_convert_diann.py` + `test_converters_base.py`
(71) all pass.

Note: `converters/base.py` has a separate `SampleTracker` with the same regex, but its suffix
behaviour is pinned by its own tests (`"My Sample 42"` asserted to match) — left for a separate call
if you want it aligned too.
