### PR TITLE
Do not fail a file for a term the bundled ontology snapshot has not caught up to

### DIFF
--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -546,6 +546,17 @@ if OLS_AVAILABLE:
                         suggestion_parts.append(f"Examples: {example_str}")
                     suggestion = ". ".join(suggestion_parts)
 
+                    # Offline, a miss is ambiguous: the bundled ontology snapshot cannot
+                    # distinguish a term that does not exist from one minted after the
+                    # snapshot was built. Report it so it stays visible, but do not fail a
+                    # file whose term may be perfectly valid -- the same treatment accession
+                    # agreement gets when it cannot be verified.
+                    unverifiable = self.use_ols_cache_only
+                    if unverifiable:
+                        suggestion += (
+                            ". Not found in the bundled ontology snapshot; it may be newer than "
+                            "the snapshot. Re-run without --use_ols_cache_only to check against OLS"
+                        )
                     errors.append(
                         LogicError.from_code(
                             ErrorCode.ONTOLOGY_TERM_NOT_FOUND,
@@ -553,7 +564,7 @@ if OLS_AVAILABLE:
                             column=column_name,
                             ontologies=";".join(self.ontologies),
                             row=idx,
-                            error_type=self.error_level,
+                            error_type=logging.WARNING if unverifiable else self.error_level,
                             suggestion=suggestion,
                         )
                     )

--- a/tests/test_issue_341.py
+++ b/tests/test_issue_341.py
@@ -1,0 +1,53 @@
+"""Tests for issue #341 - a term missing from the bundled snapshot is not a hard error offline."""
+
+import logging
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.ontology
+
+
+def _client(search):
+    from sdrf_pipelines.ols.ols import OlsClient
+
+    c = OlsClient.__new__(OlsClient)
+    c.use_cache = False
+    c.search = search  # type: ignore[method-assign]
+    return c
+
+
+def _validator(cache_only):
+    from sdrf_pipelines.sdrf.validators import OntologyValidator
+
+    def fake_search(term, ontology=None, exact=True, use_ols_cache_only=False, **kwargs):
+        # the snapshot knows 'single cell' but not the newer 'study sample'
+        return [{"label": "single cell", "obo_id": "PRIDE:0000897"}] if term.lower() == "single cell" else []
+
+    params = {"ontologies": ["pride"], "error_level": "error"}
+    if cache_only:
+        params["use_ols_cache_only"] = True
+    return OntologyValidator(params=params, client=_client(fake_search))
+
+
+def _run(v, value):
+    return v.validate(pd.Series([value]), column_name="characteristics[sample type]")
+
+
+def test_known_term_passes_offline():
+    assert _run(_validator(cache_only=True), "single cell") == []
+
+
+def test_term_newer_than_snapshot_is_a_warning_offline():
+    """PRIDE:0001013 'study sample' post-dates the bundled snapshot; it must not fail the file."""
+    errors = _run(_validator(cache_only=True), "study sample")
+    assert [e.error_code.value for e in errors] == ["ONTOLOGY_TERM_NOT_FOUND"]
+    assert all(e.error_type == logging.WARNING for e in errors)
+    assert "may be newer than" in str(errors[0])
+
+
+def test_unknown_term_is_still_an_error_online():
+    """With OLS reachable a miss is authoritative, so it stays an error."""
+    errors = _run(_validator(cache_only=False), "study sample")
+    assert [e.error_code.value for e in errors] == ["ONTOLOGY_TERM_NOT_FOUND"]
+    assert all(e.error_type == logging.ERROR for e in errors)


### PR DESCRIPTION
Closes #341.

`--use_ols_cache_only` resolves terms against ontology snapshots shipped with the package. A snapshot **always lags** the live ontology, so a miss offline is ambiguous: the term may not exist, or it may simply be **newer than the snapshot**. The validator treated both as `ONTOLOGY_TERM_NOT_FOUND` at error level and failed the file.

### This is already biting
`study sample` is **`PRIDE:0001013`**, a child of `PRIDE:0000895` and the **declared default** for `characteristics[sample type]` in `affinity-proteomics` (bigbio/sdrf-templates#62). It is absent from the bundled `pride.parquet` (verified: cache-only search returns **0 hits**, while `single cell` and `multiplex sample` return 1 each).

So every file using the value the templates *tell writers to use* fails offline validation while passing against OLS. **25 datasets already merged** in sdrf-annotated-datasets carry it, and it produced spurious failures on at least two PRs there.

### Change
Offline, a miss is reported as a **warning** rather than an error, with a suggestion naming the cause and pointing at a live re-run:

```
WARNING: Term: study sample in column 'characteristics[sample type]', is not found ...
  ... Not found in the bundled ontology snapshot; it may be newer than the snapshot.
      Re-run without --use_ols_cache_only to check against OLS
```

**Nothing is hidden** — the finding is still emitted. And **with OLS reachable a miss remains authoritative and stays an error**, so online validation is unchanged. This mirrors how accession agreement is treated when it cannot be verified (#332): cache-only genuinely cannot distinguish the two cases, so it should not assert the stronger one.

### Verified
- Three new tests: a known term passes offline; a term newer than the snapshot is a **warning** offline; an unknown term is **still an error** online.
- End-to-end on the file that triggered the issue, the message changes from `ERROR:` to `WARNING:`.
- Full suite: **383 passed** (non-ontology) and **25 passed** (ontology, including the new ones). Lint and format clean.

Regenerating the snapshots is still worth doing and does not conflict with this — it narrows the window rather than closing it, since any snapshot goes stale again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cache-only ontology validation to report terms missing from the bundled snapshot as warnings instead of errors.
  * Added guidance indicating that a missing term may be newer than the snapshot and suggesting validation without cache-only mode.
  * Preserved hard-error behavior when online ontology validation is available.

* **Tests**
  * Added coverage for known and newer ontology terms in offline and online validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->