### PR TITLE
Enhance validation and parsing with ontology term handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   DIA-NN site string (`Phospho,79.966331,STY`), and the same modification (same name + mass)
   declared across several SDRF cells (`Oxidation` on `M` and on `P`) is merged into a single entry
   (`Oxidation,15.994915,MP`).
+- MHCquant converter (`converters/mhcquant/constants.py`): `convert-mhcquant` no longer fails with
+  `Unrecognized instrument` for LTQ Orbitrap Elite / Velos deposits (e.g. PXD012083, PXD004746). They now
+  fall back to the `qe` preset family rather than `xl`, because `xl` encodes ion-trap MS2 (0.50025 Da)
+  and `comment[ms2 mass analyzer]` already downgrades genuine ion-trap runs to low_res.
 
 ### Chores
 - Update the `sdrf-templates` submodule to the latest `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,7 @@
   DIA-NN site string (`Phospho,79.966331,STY`), and the same modification (same name + mass)
   declared across several SDRF cells (`Oxidation` on `M` and on `P`) is merged into a single entry
   (`Oxidation,15.994915,MP`).
-- MHCquant converter (`converters/mhcquant/constants.py`): `convert-mhcquant` no longer fails with
-  `Unrecognized instrument` for LTQ Orbitrap Elite / Velos deposits (e.g. PXD012083, PXD004746). They now
-  fall back to the `qe` preset family rather than `xl`, because `xl` encodes ion-trap MS2 (0.50025 Da)
-  and `comment[ms2 mass analyzer]` already downgrades genuine ion-trap runs to low_res.
+- MHCquant converter: support LTQ Orbitrap Elite/Velos instruments (mapped to the `qe` presets; e.g. PXD012083, PXD004746).
 
 ### Chores
 - Update the `sdrf-templates` submodule to the latest `main`.

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -27,11 +27,11 @@ MHC_CLASS_PEPTIDE_LENGTHS = {
 INSTRUMENT_PRESET_MAP = [
     (["lumos", "fusion", "exploris", "eclipse"], "lumos"),
     (["q exactive", "exactive"], "qe"),
+    # Velos/Elite behave like Q Exactive instruments, so they share the qe presets
+    (["elite", "velos"], "qe"),
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # Velos/Elite behave like Q Exactive instruments, so they share the qe presets
-    (["elite", "velos"], "qe"),
 ]
 
 PRESET_COLUMNS = [

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,8 +30,7 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # "qe", not "xl": xl means ion-trap MS2; Elite/Velos usually acquire Orbitrap MS2 and
-    # resolve_fragment_tolerance() handles the ion-trap case via comment[ms2 mass analyzer].
+    # Elite/Velos acquire Orbitrap MS2 by default; ion-trap MS2 is handled by resolve_fragment_tolerance()
     (["elite", "velos"], "qe"),
 ]
 

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,7 +30,7 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # Elite/Velos acquire Orbitrap MS2 by default; ion-trap MS2 is handled by resolve_fragment_tolerance()
+    # Velos/Elite behave like Q Exactive instruments, so they share the qe presets
     (["elite", "velos"], "qe"),
 ]
 

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,6 +30,13 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
+    # Elite/Velos deliberately map to "qe", NOT "xl". The xl preset differs from qe only on the
+    # fragment side (0.50025 Da / bin offset 0.4 / low_res), i.e. it encodes ion-trap MS2, not an
+    # instrument model. Elite/Velos deposits commonly acquire MS2 in the Orbitrap (e.g. R=15,000),
+    # so "qe" is the correct fallback; resolve_fragment_tolerance() still downgrades a genuine
+    # ion-trap run to low_res when comment[ms2 mass analyzer] is populated. Mapping to "xl" would
+    # silently apply 0.50025 Da to any Elite/Velos file that omits that column.
+    (["elite", "velos"], "qe"),
 ]
 
 PRESET_COLUMNS = [

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,12 +30,8 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # Elite/Velos deliberately map to "qe", NOT "xl". The xl preset differs from qe only on the
-    # fragment side (0.50025 Da / bin offset 0.4 / low_res), i.e. it encodes ion-trap MS2, not an
-    # instrument model. Elite/Velos deposits commonly acquire MS2 in the Orbitrap (e.g. R=15,000),
-    # so "qe" is the correct fallback; resolve_fragment_tolerance() still downgrades a genuine
-    # ion-trap run to low_res when comment[ms2 mass analyzer] is populated. Mapping to "xl" would
-    # silently apply 0.50025 Da to any Elite/Velos file that omits that column.
+    # "qe", not "xl": xl means ion-trap MS2; Elite/Velos usually acquire Orbitrap MS2 and
+    # resolve_fragment_tolerance() handles the ion-trap case via comment[ms2 mass analyzer].
     (["elite", "velos"], "qe"),
 ]
 

--- a/src/sdrf_pipelines/sdrf/schemas/models.py
+++ b/src/sdrf_pipelines/sdrf/schemas/models.py
@@ -54,5 +54,6 @@ class SchemaDefinition(BaseModel):
     usable_alone: bool = True
     layer: str | None = None
     mutually_exclusive_with: list[str] = Field(default_factory=list)
+    excludes: dict[str, Any] = Field(default_factory=dict, description="Templates to exclude from combination")
     validators: list[ValidatorConfig] = Field(default_factory=list)
     columns: list[ColumnDefinition] = Field(default_factory=list)

--- a/src/sdrf_pipelines/sdrf/schemas/registry.py
+++ b/src/sdrf_pipelines/sdrf/schemas/registry.py
@@ -455,10 +455,10 @@ class SchemaRegistry:
 
     def _get_excluded_templates(self, schema_names: list[str]) -> set[str]:
         """Get all templates that should be excluded based on the schemas being combined.
-        
+
         Args:
             schema_names: List of schema names being combined
-            
+
         Returns:
             Set of excluded template names
         """
@@ -474,26 +474,26 @@ class SchemaRegistry:
 
     def _get_template_columns(self, template_name: str) -> set[str]:
         """Get all column names defined in a template (including inherited columns).
-        
+
         Args:
             template_name: Name of the template
-            
+
         Returns:
             Set of column names defined in this template
         """
         if template_name not in self.raw_schema_data:
             return set()
-        
+
         # Get the raw schema data (before inheritance processing)
         raw_schema = self.raw_schema_data[template_name]
         columns = set()
-        
+
         # Collect columns from this template
         if "columns" in raw_schema:
             for col_def in raw_schema["columns"]:
                 if "name" in col_def:
                     columns.add(col_def["name"])
-        
+
         # Also collect columns from parent templates
         extends = raw_schema.get("extends")
         if extends:
@@ -501,7 +501,7 @@ class SchemaRegistry:
             if parent_name:
                 parent_columns = self._get_template_columns(parent_name)
                 columns.update(parent_columns)
-        
+
         return columns
 
     def compile_columns_from_schemas(
@@ -569,15 +569,15 @@ class SchemaRegistry:
 
         # Get all columns from combined schemas
         _, merge_column_definitions = self.compile_columns_from_schemas(schema_names, strategy)
-        
+
         # Get all templates that should be excluded
         excluded_templates = self._get_excluded_templates(schema_names)
-        
+
         # Collect columns that should be excluded
         excluded_columns = set()
         for excluded_template in excluded_templates:
             excluded_columns.update(self._get_template_columns(excluded_template))
-        
+
         # Build final columns list, excluding columns from excluded templates
         columns = []
         for section in ["source name", "characteristics", "special", "comment", "factor value"]:

--- a/src/sdrf_pipelines/sdrf/schemas/registry.py
+++ b/src/sdrf_pipelines/sdrf/schemas/registry.py
@@ -453,6 +453,57 @@ class SchemaRegistry:
                 ordered_columns.append(col_name)
         return ordered_columns
 
+    def _get_excluded_templates(self, schema_names: list[str]) -> set[str]:
+        """Get all templates that should be excluded based on the schemas being combined.
+        
+        Args:
+            schema_names: List of schema names being combined
+            
+        Returns:
+            Set of excluded template names
+        """
+        excluded = set()
+        for schema_name in schema_names:
+            schema = self.get_schema(schema_name)
+            if schema and schema.excludes:
+                # The excludes field contains a dict with 'templates' key that lists excluded templates
+                templates_to_exclude = schema.excludes.get("templates", [])
+                if isinstance(templates_to_exclude, list):
+                    excluded.update(templates_to_exclude)
+        return excluded
+
+    def _get_template_columns(self, template_name: str) -> set[str]:
+        """Get all column names defined in a template (including inherited columns).
+        
+        Args:
+            template_name: Name of the template
+            
+        Returns:
+            Set of column names defined in this template
+        """
+        if template_name not in self.raw_schema_data:
+            return set()
+        
+        # Get the raw schema data (before inheritance processing)
+        raw_schema = self.raw_schema_data[template_name]
+        columns = set()
+        
+        # Collect columns from this template
+        if "columns" in raw_schema:
+            for col_def in raw_schema["columns"]:
+                if "name" in col_def:
+                    columns.add(col_def["name"])
+        
+        # Also collect columns from parent templates
+        extends = raw_schema.get("extends")
+        if extends:
+            parent_name, _ = parse_extends(extends)
+            if parent_name:
+                parent_columns = self._get_template_columns(parent_name)
+                columns.update(parent_columns)
+        
+        return columns
+
     def compile_columns_from_schemas(
         self, schema_names: list[str], strategy: MergeStrategy = MergeStrategy.COMBINE
     ) -> tuple[list[str], dict[str, OrderedDict[str, ColumnDefinition]]]:
@@ -516,11 +567,23 @@ class SchemaRegistry:
             else:
                 raise ValueError(f"Schema '{schema_name}' not found in registry")
 
+        # Get all columns from combined schemas
         _, merge_column_definitions = self.compile_columns_from_schemas(schema_names, strategy)
+        
+        # Get all templates that should be excluded
+        excluded_templates = self._get_excluded_templates(schema_names)
+        
+        # Collect columns that should be excluded
+        excluded_columns = set()
+        for excluded_template in excluded_templates:
+            excluded_columns.update(self._get_template_columns(excluded_template))
+        
+        # Build final columns list, excluding columns from excluded templates
         columns = []
         for section in ["source name", "characteristics", "special", "comment", "factor value"]:
             for col_name in merge_column_definitions[section]:
-                columns.append(merge_column_definitions[section][col_name])
+                if col_name not in excluded_columns:
+                    columns.append(merge_column_definitions[section][col_name])
 
         combined_schema.columns = columns
 

--- a/src/sdrf_pipelines/sdrf/validators.py
+++ b/src/sdrf_pipelines/sdrf/validators.py
@@ -546,6 +546,17 @@ if OLS_AVAILABLE:
                         suggestion_parts.append(f"Examples: {example_str}")
                     suggestion = ". ".join(suggestion_parts)
 
+                    # Offline, a miss is ambiguous: the bundled ontology snapshot cannot
+                    # distinguish a term that does not exist from one minted after the
+                    # snapshot was built. Report it so it stays visible, but do not fail a
+                    # file whose term may be perfectly valid -- the same treatment accession
+                    # agreement gets when it cannot be verified.
+                    unverifiable = self.use_ols_cache_only
+                    if unverifiable:
+                        suggestion += (
+                            ". Not found in the bundled ontology snapshot; it may be newer than "
+                            "the snapshot. Re-run without --use_ols_cache_only to check against OLS"
+                        )
                     errors.append(
                         LogicError.from_code(
                             ErrorCode.ONTOLOGY_TERM_NOT_FOUND,
@@ -553,7 +564,7 @@ if OLS_AVAILABLE:
                             column=column_name,
                             ontologies=";".join(self.ontologies),
                             row=idx,
-                            error_type=self.error_level,
+                            error_type=logging.WARNING if unverifiable else self.error_level,
                             suggestion=suggestion,
                         )
                     )

--- a/tests/test_issue_341.py
+++ b/tests/test_issue_341.py
@@ -1,0 +1,53 @@
+"""Tests for issue #341 - a term missing from the bundled snapshot is not a hard error offline."""
+
+import logging
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.ontology
+
+
+def _client(search):
+    from sdrf_pipelines.ols.ols import OlsClient
+
+    c = OlsClient.__new__(OlsClient)
+    c.use_cache = False
+    c.search = search  # type: ignore[method-assign]
+    return c
+
+
+def _validator(cache_only):
+    from sdrf_pipelines.sdrf.validators import OntologyValidator
+
+    def fake_search(term, ontology=None, exact=True, use_ols_cache_only=False, **kwargs):
+        # the snapshot knows 'single cell' but not the newer 'study sample'
+        return [{"label": "single cell", "obo_id": "PRIDE:0000897"}] if term.lower() == "single cell" else []
+
+    params = {"ontologies": ["pride"], "error_level": "error"}
+    if cache_only:
+        params["use_ols_cache_only"] = True
+    return OntologyValidator(params=params, client=_client(fake_search))
+
+
+def _run(v, value):
+    return v.validate(pd.Series([value]), column_name="characteristics[sample type]")
+
+
+def test_known_term_passes_offline():
+    assert _run(_validator(cache_only=True), "single cell") == []
+
+
+def test_term_newer_than_snapshot_is_a_warning_offline():
+    """PRIDE:0001013 'study sample' post-dates the bundled snapshot; it must not fail the file."""
+    errors = _run(_validator(cache_only=True), "study sample")
+    assert [e.error_code.value for e in errors] == ["ONTOLOGY_TERM_NOT_FOUND"]
+    assert all(e.error_type == logging.WARNING for e in errors)
+    assert "may be newer than" in str(errors[0])
+
+
+def test_unknown_term_is_still_an_error_online():
+    """With OLS reachable a miss is authoritative, so it stays an error."""
+    errors = _run(_validator(cache_only=False), "study sample")
+    assert [e.error_code.value for e in errors] == ["ONTOLOGY_TERM_NOT_FOUND"]
+    assert all(e.error_type == logging.ERROR for e in errors)

--- a/tests/test_mhcquant.py
+++ b/tests/test_mhcquant.py
@@ -157,7 +157,7 @@ class TestErrorHandling:
 
 
 class TestEliteVelosInstruments:
-    """LTQ Orbitrap Elite/Velos map to the qe presets; ion-trap MS2 still resolves to low_res."""
+    """LTQ Orbitrap Elite/Velos share the qe presets."""
 
     @staticmethod
     def _write_sdrf(path: Path, instrument: str, analyzer: str, frag_tol: str, dissociation: str) -> Path:

--- a/tests/test_mhcquant.py
+++ b/tests/test_mhcquant.py
@@ -154,3 +154,76 @@ class TestErrorHandling:
         sdrf_path.write_text("source name\tcomment[data file]\npatient_1\trun1.raw\n")
         with pytest.raises(ValueError, match="No factor value columns"):
             converter.convert(str(sdrf_path), str(tmpdir / "ss.tsv"), output_presets=str(tmpdir / "p.tsv"))
+
+
+class TestEliteVelosInstruments:
+    """LTQ Orbitrap Elite / Velos deposits must map to the ``qe`` preset family.
+
+    The ``xl`` preset encodes ion-trap MS2 (0.50025 Da), not an instrument model. Elite/Velos
+    runs commonly read MS2 out of the Orbitrap, so ``qe`` is the safe fallback and
+    ``resolve_fragment_tolerance`` downgrades to low_res when the MS2 analyzer is an ion trap.
+    Public examples that previously failed with ``Unrecognized instrument``: PXD012083, PXD004746.
+    """
+
+    @staticmethod
+    def _write_sdrf(path: Path, instrument: str, analyzer: str, frag_tol: str, dissociation: str) -> Path:
+        header = "\t".join(
+            [
+                "source name",
+                "characteristics[mhc protein complex]",
+                "comment[data file]",
+                "comment[instrument]",
+                "comment[ms2 mass analyzer]",
+                "comment[dissociation method]",
+                "comment[modification parameters]",
+                "comment[precursor mass tolerance]",
+                "comment[fragment mass tolerance]",
+                "factor value[source name]",
+            ]
+        )
+        row = "\t".join(
+            [
+                "patient_1",
+                "MHC class I protein complex",
+                "run1.raw",
+                f"NT={instrument};AC=MS:0000000",
+                f"NT={analyzer};AC=MS:0000000",
+                f"NT={dissociation};AC=MS:0000000",
+                "NT=Oxidation;MT=Variable;TA=M;AC=UNIMOD:35;PP=Anywhere",
+                "5 ppm",
+                frag_tol,
+                "patient_1",
+            ]
+        )
+        path.write_text(f"{header}\n{row}\n")
+        return path
+
+    def _convert(self, converter, tmpdir, instrument, analyzer, frag_tol="0.02 Da", dissociation="HCD"):
+        sdrf = self._write_sdrf(tmpdir / "elite.sdrf.tsv", instrument, analyzer, frag_tol, dissociation)
+        ss, presets = tmpdir / "ss.tsv", tmpdir / "presets.tsv"
+        converter.convert(str(sdrf), str(ss), output_presets=str(presets))
+        return pd.read_csv(ss, sep="\t"), pd.read_csv(presets, sep="\t").iloc[0]
+
+    def test_orbitrap_elite_high_res_maps_to_qe(self, converter, tmpdir):
+        df, p = self._convert(converter, tmpdir, "Orbitrap Elite", "orbitrap")
+        assert list(df["SearchPreset"]) == ["qe_class1"]
+        assert p["PresetName"] == "qe_class1"
+        assert p["Instrument"] == "high_res"
+        assert p["FragmentMassTolerance"] == 0.01
+
+    def test_ltq_orbitrap_elite_ion_trap_downgrades_to_low_res(self, converter, tmpdir):
+        _, p = self._convert(converter, tmpdir, "LTQ Orbitrap Elite", "ion trap", "0.5 Da")
+        assert p["Instrument"] == "low_res"
+        assert p["FragmentMassTolerance"] == 0.50025
+        assert p["FragmentBinOffset"] == 0.4
+
+    def test_ltq_orbitrap_velos_maps_to_qe(self, converter, tmpdir):
+        df, _ = self._convert(converter, tmpdir, "LTQ Orbitrap Velos", "orbitrap")
+        assert list(df["SearchPreset"]) == ["qe_class1"]
+
+    def test_ltq_orbitrap_xl_ion_trap_stays_low_res(self, converter, tmpdir):
+        """Regression: the XL mapping is unchanged (CID matches the xl_class1 default)."""
+        df, p = self._convert(converter, tmpdir, "LTQ Orbitrap XL", "ion trap", "0.5 Da", dissociation="CID")
+        assert list(df["SearchPreset"]) == ["xl_class1"]
+        assert p["Instrument"] == "low_res"
+        assert p["FragmentMassTolerance"] == 0.50025

--- a/tests/test_mhcquant.py
+++ b/tests/test_mhcquant.py
@@ -157,13 +157,7 @@ class TestErrorHandling:
 
 
 class TestEliteVelosInstruments:
-    """LTQ Orbitrap Elite / Velos deposits must map to the ``qe`` preset family.
-
-    The ``xl`` preset encodes ion-trap MS2 (0.50025 Da), not an instrument model. Elite/Velos
-    runs commonly read MS2 out of the Orbitrap, so ``qe`` is the safe fallback and
-    ``resolve_fragment_tolerance`` downgrades to low_res when the MS2 analyzer is an ion trap.
-    Public examples that previously failed with ``Unrecognized instrument``: PXD012083, PXD004746.
-    """
+    """LTQ Orbitrap Elite/Velos map to the qe presets; ion-trap MS2 still resolves to low_res."""
 
     @staticmethod
     def _write_sdrf(path: Path, instrument: str, analyzer: str, frag_tol: str, dissociation: str) -> Path:


### PR DESCRIPTION
This pull request introduces improvements to the schema combination logic and ontology validation handling, especially when working offline with a bundled ontology snapshot. The main changes add support for excluding templates and their columns during schema combination, and ensure that ontology terms missing from the bundled snapshot are treated as warnings (not errors) when OLS is not reachable. Comprehensive tests are included for the new validation behavior.

**Schema Combination Enhancements:**
* Added an `excludes` field to the `SchemaDefinition` model, allowing templates to specify other templates to exclude from combination (`models.py`).
* Implemented helper methods `_get_excluded_templates` and `_get_template_columns` in `SchemaRegistry` to collect templates and columns that should be excluded during schema combination (`registry.py`).
* Updated the `combine_schemas` method to remove columns from excluded templates when merging schemas (`registry.py`).

**Ontology Validation Improvements:**
* Modified the ontology validator to treat missing terms as warnings (not errors) when running offline with `--use_ols_cache_only`, and updated the error suggestion message accordingly (`validators.py`).

**Testing:**
* Added tests to verify that ontology terms missing from the bundled snapshot are warnings offline but remain errors when OLS is reachable (`test_issue_341.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Schema combinations can now exclude specific templates and their associated columns, including inherited columns.
  - MHCquant conversion now supports LTQ Orbitrap Elite and Velos instruments with appropriate preset mappings.

- **Bug Fixes**
  - Offline ontology validation now reports terms missing from the bundled snapshot as warnings, with guidance to retry using online validation.
  - Unknown terms remain errors when online ontology access is available.

- **Tests**
  - Added coverage for ontology validation and Elite/Velos instrument conversion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->