### PR TITLE
fix(mhcquant): support LTQ Orbitrap Elite/Velos instruments in convert-mhcquant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
   DIA-NN site string (`Phospho,79.966331,STY`), and the same modification (same name + mass)
   declared across several SDRF cells (`Oxidation` on `M` and on `P`) is merged into a single entry
   (`Oxidation,15.994915,MP`).
+- MHCquant converter (`converters/mhcquant/constants.py`): `convert-mhcquant` no longer fails with
+  `Unrecognized instrument` for LTQ Orbitrap Elite / Velos deposits (e.g. PXD012083, PXD004746). They now
+  fall back to the `qe` preset family rather than `xl`, because `xl` encodes ion-trap MS2 (0.50025 Da)
+  and `comment[ms2 mass analyzer]` already downgrades genuine ion-trap runs to low_res.
 
 ### Chores
 - Update the `sdrf-templates` submodule to the latest `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,7 @@
   DIA-NN site string (`Phospho,79.966331,STY`), and the same modification (same name + mass)
   declared across several SDRF cells (`Oxidation` on `M` and on `P`) is merged into a single entry
   (`Oxidation,15.994915,MP`).
-- MHCquant converter (`converters/mhcquant/constants.py`): `convert-mhcquant` no longer fails with
-  `Unrecognized instrument` for LTQ Orbitrap Elite / Velos deposits (e.g. PXD012083, PXD004746). They now
-  fall back to the `qe` preset family rather than `xl`, because `xl` encodes ion-trap MS2 (0.50025 Da)
-  and `comment[ms2 mass analyzer]` already downgrades genuine ion-trap runs to low_res.
+- MHCquant converter: support LTQ Orbitrap Elite/Velos instruments (mapped to the `qe` presets; e.g. PXD012083, PXD004746).
 
 ### Chores
 - Update the `sdrf-templates` submodule to the latest `main`.

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -27,11 +27,11 @@ MHC_CLASS_PEPTIDE_LENGTHS = {
 INSTRUMENT_PRESET_MAP = [
     (["lumos", "fusion", "exploris", "eclipse"], "lumos"),
     (["q exactive", "exactive"], "qe"),
+    # Velos/Elite behave like Q Exactive instruments, so they share the qe presets
+    (["elite", "velos"], "qe"),
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # Velos/Elite behave like Q Exactive instruments, so they share the qe presets
-    (["elite", "velos"], "qe"),
 ]
 
 PRESET_COLUMNS = [

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,8 +30,7 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # "qe", not "xl": xl means ion-trap MS2; Elite/Velos usually acquire Orbitrap MS2 and
-    # resolve_fragment_tolerance() handles the ion-trap case via comment[ms2 mass analyzer].
+    # Elite/Velos acquire Orbitrap MS2 by default; ion-trap MS2 is handled by resolve_fragment_tolerance()
     (["elite", "velos"], "qe"),
 ]
 

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,7 +30,7 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # Elite/Velos acquire Orbitrap MS2 by default; ion-trap MS2 is handled by resolve_fragment_tolerance()
+    # Velos/Elite behave like Q Exactive instruments, so they share the qe presets
     (["elite", "velos"], "qe"),
 ]
 

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,6 +30,13 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
+    # Elite/Velos deliberately map to "qe", NOT "xl". The xl preset differs from qe only on the
+    # fragment side (0.50025 Da / bin offset 0.4 / low_res), i.e. it encodes ion-trap MS2, not an
+    # instrument model. Elite/Velos deposits commonly acquire MS2 in the Orbitrap (e.g. R=15,000),
+    # so "qe" is the correct fallback; resolve_fragment_tolerance() still downgrades a genuine
+    # ion-trap run to low_res when comment[ms2 mass analyzer] is populated. Mapping to "xl" would
+    # silently apply 0.50025 Da to any Elite/Velos file that omits that column.
+    (["elite", "velos"], "qe"),
 ]
 
 PRESET_COLUMNS = [

--- a/src/sdrf_pipelines/converters/mhcquant/constants.py
+++ b/src/sdrf_pipelines/converters/mhcquant/constants.py
@@ -30,12 +30,8 @@ INSTRUMENT_PRESET_MAP = [
     (["timstof", "tims tof"], "timstof"),
     (["astral"], "astral"),
     (["ltq orbitrap xl", "orbitrap xl"], "xl"),
-    # Elite/Velos deliberately map to "qe", NOT "xl". The xl preset differs from qe only on the
-    # fragment side (0.50025 Da / bin offset 0.4 / low_res), i.e. it encodes ion-trap MS2, not an
-    # instrument model. Elite/Velos deposits commonly acquire MS2 in the Orbitrap (e.g. R=15,000),
-    # so "qe" is the correct fallback; resolve_fragment_tolerance() still downgrades a genuine
-    # ion-trap run to low_res when comment[ms2 mass analyzer] is populated. Mapping to "xl" would
-    # silently apply 0.50025 Da to any Elite/Velos file that omits that column.
+    # "qe", not "xl": xl means ion-trap MS2; Elite/Velos usually acquire Orbitrap MS2 and
+    # resolve_fragment_tolerance() handles the ion-trap case via comment[ms2 mass analyzer].
     (["elite", "velos"], "qe"),
 ]
 

--- a/tests/test_mhcquant.py
+++ b/tests/test_mhcquant.py
@@ -157,7 +157,7 @@ class TestErrorHandling:
 
 
 class TestEliteVelosInstruments:
-    """LTQ Orbitrap Elite/Velos map to the qe presets; ion-trap MS2 still resolves to low_res."""
+    """LTQ Orbitrap Elite/Velos share the qe presets."""
 
     @staticmethod
     def _write_sdrf(path: Path, instrument: str, analyzer: str, frag_tol: str, dissociation: str) -> Path:

--- a/tests/test_mhcquant.py
+++ b/tests/test_mhcquant.py
@@ -154,3 +154,76 @@ class TestErrorHandling:
         sdrf_path.write_text("source name\tcomment[data file]\npatient_1\trun1.raw\n")
         with pytest.raises(ValueError, match="No factor value columns"):
             converter.convert(str(sdrf_path), str(tmpdir / "ss.tsv"), output_presets=str(tmpdir / "p.tsv"))
+
+
+class TestEliteVelosInstruments:
+    """LTQ Orbitrap Elite / Velos deposits must map to the ``qe`` preset family.
+
+    The ``xl`` preset encodes ion-trap MS2 (0.50025 Da), not an instrument model. Elite/Velos
+    runs commonly read MS2 out of the Orbitrap, so ``qe`` is the safe fallback and
+    ``resolve_fragment_tolerance`` downgrades to low_res when the MS2 analyzer is an ion trap.
+    Public examples that previously failed with ``Unrecognized instrument``: PXD012083, PXD004746.
+    """
+
+    @staticmethod
+    def _write_sdrf(path: Path, instrument: str, analyzer: str, frag_tol: str, dissociation: str) -> Path:
+        header = "\t".join(
+            [
+                "source name",
+                "characteristics[mhc protein complex]",
+                "comment[data file]",
+                "comment[instrument]",
+                "comment[ms2 mass analyzer]",
+                "comment[dissociation method]",
+                "comment[modification parameters]",
+                "comment[precursor mass tolerance]",
+                "comment[fragment mass tolerance]",
+                "factor value[source name]",
+            ]
+        )
+        row = "\t".join(
+            [
+                "patient_1",
+                "MHC class I protein complex",
+                "run1.raw",
+                f"NT={instrument};AC=MS:0000000",
+                f"NT={analyzer};AC=MS:0000000",
+                f"NT={dissociation};AC=MS:0000000",
+                "NT=Oxidation;MT=Variable;TA=M;AC=UNIMOD:35;PP=Anywhere",
+                "5 ppm",
+                frag_tol,
+                "patient_1",
+            ]
+        )
+        path.write_text(f"{header}\n{row}\n")
+        return path
+
+    def _convert(self, converter, tmpdir, instrument, analyzer, frag_tol="0.02 Da", dissociation="HCD"):
+        sdrf = self._write_sdrf(tmpdir / "elite.sdrf.tsv", instrument, analyzer, frag_tol, dissociation)
+        ss, presets = tmpdir / "ss.tsv", tmpdir / "presets.tsv"
+        converter.convert(str(sdrf), str(ss), output_presets=str(presets))
+        return pd.read_csv(ss, sep="\t"), pd.read_csv(presets, sep="\t").iloc[0]
+
+    def test_orbitrap_elite_high_res_maps_to_qe(self, converter, tmpdir):
+        df, p = self._convert(converter, tmpdir, "Orbitrap Elite", "orbitrap")
+        assert list(df["SearchPreset"]) == ["qe_class1"]
+        assert p["PresetName"] == "qe_class1"
+        assert p["Instrument"] == "high_res"
+        assert p["FragmentMassTolerance"] == 0.01
+
+    def test_ltq_orbitrap_elite_ion_trap_downgrades_to_low_res(self, converter, tmpdir):
+        _, p = self._convert(converter, tmpdir, "LTQ Orbitrap Elite", "ion trap", "0.5 Da")
+        assert p["Instrument"] == "low_res"
+        assert p["FragmentMassTolerance"] == 0.50025
+        assert p["FragmentBinOffset"] == 0.4
+
+    def test_ltq_orbitrap_velos_maps_to_qe(self, converter, tmpdir):
+        df, _ = self._convert(converter, tmpdir, "LTQ Orbitrap Velos", "orbitrap")
+        assert list(df["SearchPreset"]) == ["qe_class1"]
+
+    def test_ltq_orbitrap_xl_ion_trap_stays_low_res(self, converter, tmpdir):
+        """Regression: the XL mapping is unchanged (CID matches the xl_class1 default)."""
+        df, p = self._convert(converter, tmpdir, "LTQ Orbitrap XL", "ion trap", "0.5 Da", dissociation="CID")
+        assert list(df["SearchPreset"]) == ["xl_class1"]
+        assert p["Instrument"] == "low_res"
+        assert p["FragmentMassTolerance"] == 0.50025

--- a/tests/test_mhcquant.py
+++ b/tests/test_mhcquant.py
@@ -157,13 +157,7 @@ class TestErrorHandling:
 
 
 class TestEliteVelosInstruments:
-    """LTQ Orbitrap Elite / Velos deposits must map to the ``qe`` preset family.
-
-    The ``xl`` preset encodes ion-trap MS2 (0.50025 Da), not an instrument model. Elite/Velos
-    runs commonly read MS2 out of the Orbitrap, so ``qe`` is the safe fallback and
-    ``resolve_fragment_tolerance`` downgrades to low_res when the MS2 analyzer is an ion trap.
-    Public examples that previously failed with ``Unrecognized instrument``: PXD012083, PXD004746.
-    """
+    """LTQ Orbitrap Elite/Velos map to the qe presets; ion-trap MS2 still resolves to low_res."""
 
     @staticmethod
     def _write_sdrf(path: Path, instrument: str, analyzer: str, frag_tol: str, dissociation: str) -> Path:


### PR DESCRIPTION
`convert-mhcquant` raised `Unrecognized instrument` for LTQ Orbitrap Elite/Velos deposits (e.g. PXD012083, PXD004746). Adds them to `INSTRUMENT_PRESET_MAP`, mapped to `qe`.

- `qe` rather than `xl`: xl encodes ion-trap MS2, and Elite/Velos usually acquire Orbitrap MS2; `comment[ms2 mass analyzer]` still forces low_res for ion-trap runs.
- Tests for Elite (Orbitrap and ion-trap MS2), Velos, and an XL regression.