### PR TITLE
Fix OpenMS SILAC designs and add multi-channel regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,26 @@ jobs:
       - name: Run core tests (excluding ontology)
         run: uv run pytest -m "not ontology" -v
 
+  test-openms-designs:
+    name: OpenMS SILAC design compatibility
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv sync --group dev
+      - name: Convert SILAC designs and load them with OpenMS
+        run: |
+          uv run --with pyopenms==3.5.0 python -c "import pyopenms; print(pyopenms.__version__)"
+          uv run --with pyopenms==3.5.0 pytest tests/test_convert_openms_silac.py -v
+
   test-ontology:
     name: Ontology Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -85,7 +105,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [test-core, test-ontology]
+    needs: [test-core, test-openms-designs, test-ontology]
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/checkout@v4

--- a/src/sdrf_pipelines/converters/openms/experimental_design.py
+++ b/src/sdrf_pipelines/converters/openms/experimental_design.py
@@ -11,7 +11,12 @@ from sdrf_pipelines.converters.openms.constants import (
     SILAC_3PLEX,
     TMT_PLEXES,
 )
-from sdrf_pipelines.converters.openms.utils import get_openms_file_name, infer_itraqplex, infer_tmtplex
+from sdrf_pipelines.converters.openms.utils import (
+    get_openms_file_name,
+    infer_itraqplex,
+    infer_tmtplex,
+    parse_openms_label,
+)
 from sdrf_pipelines.utils.utils import tsv_line
 
 
@@ -112,46 +117,84 @@ class ExperimentalDesignWriter:
     def _get_label_from_labels(
         self,
         labels: list[str],
-        label_set: set,
-        label_index: dict,
-        raw: str,
+        silac_labels: set[str],
         row: pd.Series,
     ) -> str:
-        """Determine the numeric label identifier from label strings."""
-        labels_str = ",".join(labels)
+        """Map this row's channel, independently of SDRF row order or subsets."""
+        label = parse_openms_label(row["comment[label]"])
 
-        if "label free sample" in labels:
+        if label == "label free sample":
             return "1"
 
-        if "TMT" in labels_str:
-            return self._get_tmt_label(labels, label_set, label_index, raw)
+        if label.startswith("TMT"):
+            return str(TMT_PLEXES[infer_tmtplex(labels)][label])
 
-        if "SILAC" in labels_str:
-            return self._get_silac_label(labels, label_set, label_index, raw)
+        if label.startswith("SILAC"):
+            # Infer from the complete input, including channels absent from a
+            # particular raw file or removed by a condition split.
+            plex_map = self.silac3 if "silac medium" in silac_labels else self.silac2
+            return str(plex_map[label.lower()])
 
-        if "ITRAQ" in labels_str:
-            return self._get_itraq_label(labels, label_set, label_index, raw)
+        if label.startswith("ITRAQ"):
+            plex_map = self.itraq8plex if infer_itraqplex(labels) == "itraq8plex" else self.itraq4plex
+            return str(plex_map[label.lower()])
 
         raise ValueError("Label " + str(row["comment[label]"]) + " is not recognized")
 
-    def _get_tmt_label(self, labels: list[str], label_set: set, label_index: dict, raw: str) -> str:
-        """Get TMT label identifier."""
-        choice = TMT_PLEXES[infer_tmtplex(label_set)]
-        label = str(choice[labels[label_index[raw]]])
-        label_index[raw] += 1
-        return label
+    def get_silac_fraction_groups(self, sdrf: pd.DataFrame, file2technical_rep: dict[str, str]) -> dict[str, int]:
+        """Group SILAC fractions by the full channel/sample assignment and replicate.
 
-    def _get_silac_label(self, labels: list[str], label_set: set, label_index: dict, raw: str) -> str:
-        """Get SILAC label identifier."""
-        plex_map = self.silac3 if len(label_set) == 3 else self.silac2
-        return str(plex_map[labels[label_index[raw]].lower()])
+        Reusing one reference sample does not join otherwise different mixtures.
+        Swapping labels changes the mixture even when the source names are the same.
+        """
+        if not sdrf["comment[label]"].map(parse_openms_label).str.startswith("SILAC").any():
+            return {}
+        groups: dict[tuple[tuple[tuple[str, str], ...], int], int] = {}
+        file2group: dict[str, int] = {}
+        fractions: dict[int, set[str]] = {}
+        for raw, rows in sdrf.groupby("comment[data file]", sort=False):
+            labels = [parse_openms_label(label).lower() for label in rows["comment[label]"]]
+            if not any(label.startswith("silac") for label in labels):
+                continue
+            if not set(labels).issubset(self.silac3):
+                raise ValueError(f"Unsupported or mixed SILAC labels in {raw}: {labels}")
+            if len(set(labels)) != len(labels):
+                raise ValueError(f"A SILAC channel occurs more than once in {raw}")
+            replicate_values = rows.get("comment[technical replicate]", pd.Series(["1"]))
+            replicates = {1 if "not available" in value else int(value) for value in replicate_values}
+            if len(replicates) != 1:
+                raise ValueError(f"Inconsistent SILAC technical replicate identifiers in {raw}")
+            samples = [str(sample).strip() for sample in rows["source name"]]
+            key = (tuple(sorted(zip(labels, samples))), int(file2technical_rep[str(raw)]))
+            group = groups.setdefault(key, len(groups) + 1)
+            fraction_values = rows.get("comment[fraction identifier]", pd.Series(["1"]))
+            file_fractions = {"1" if "not available" in value else value for value in fraction_values}
+            if len(file_fractions) != 1:
+                raise ValueError(f"Inconsistent SILAC fraction identifiers in {raw}")
+            fraction = next(iter(file_fractions))
+            if fraction in fractions.setdefault(group, set()):
+                raise ValueError(
+                    f"Multiple SILAC files have the same mixture, technical replicate and fraction ({raw}). "
+                    "Use distinct technical replicate identifiers for repeated acquisitions."
+                )
+            fractions[group].add(fraction)
+            file2group[str(raw)] = group
+        if len(file2group) != sdrf["comment[data file]"].nunique():
+            raise ValueError("Convert SILAC and other labeling methods in separate SDRF files")
+        return file2group
 
-    def _get_itraq_label(self, labels: list[str], label_set: set, label_index: dict, raw: str) -> str:
-        """Get iTRAQ label identifier."""
-        plex_map = self.itraq8plex if infer_itraqplex(label_set) == "itraq8plex" else self.itraq4plex
-        label = str(plex_map[labels[label_index[raw]].lower()])
-        label_index[raw] += 1
-        return label
+    def _silac_file_groups(
+        self, sdrf: pd.DataFrame, file2technical_rep: dict[str, str], file2fraction_group: dict[str, int] | None
+    ) -> dict[str, int]:
+        """Renumber the selected groups consecutively without merging split mixtures."""
+        groups = (
+            self.get_silac_fraction_groups(sdrf, file2technical_rep)
+            if file2fraction_group is None
+            else file2fraction_group
+        )
+        selected = {raw: groups[raw] for raw in sdrf["comment[data file]"].unique() if raw in groups}
+        group_ids = {group: i + 1 for i, group in enumerate(dict.fromkeys(selected.values()))}
+        return {raw: group_ids[group] for raw, group in selected.items()}
 
     def _calculate_fraction_group(
         self,
@@ -185,6 +228,7 @@ class ExperimentalDesignWriter:
         extension_convert: str | None,
         file2fraction: dict[str, str],
         file2combined_factors: dict[str, str],
+        file2fraction_group: dict[str, int] | None = None,
     ):
         """Write two-table format experimental design file.
 
@@ -192,7 +236,14 @@ class ExperimentalDesignWriter:
         """
         # Build file table
         file_table = self._build_file_table(
-            sdrf, file2technical_rep, source_name_list, source_name2n_reps, file2label, extension_convert, file2fraction
+            sdrf,
+            file2technical_rep,
+            source_name_list,
+            source_name2n_reps,
+            file2label,
+            extension_convert,
+            file2fraction,
+            file2fraction_group,
         )
 
         # Build sample table
@@ -222,12 +273,16 @@ class ExperimentalDesignWriter:
         file2label: dict[str, list[str]],
         extension_convert: str | None,
         file2fraction: dict[str, str],
+        file2fraction_group: dict[str, int] | None = None,
     ) -> dict:
         """Build the file table portion of the experimental design."""
         header = ["Fraction_Group", "Fraction", "Spectra_Filepath", "Label", "Sample"]
         content = "\t".join(header) + "\n"
 
-        label_index = dict(zip(sdrf["comment[data file]"], [0] * len(sdrf["comment[data file]"])))
+        silac_labels = {
+            label.lower() for labels in file2label.values() for label in labels if label.startswith("SILAC")
+        }
+        silac_groups = self._silac_file_groups(sdrf, file2technical_rep, file2fraction_group)
         fraction_tracker = FractionGroupTracker()
         sample_tracker = SampleIdTracker()
 
@@ -239,11 +294,13 @@ class ExperimentalDesignWriter:
             fraction_group = self._calculate_fraction_group(
                 source_name, replicate, source_name_list, source_name2n_reps
             )
-            frac_group = fraction_tracker.get_fraction_group(raw, fraction_group)
+            frac_group = (
+                silac_groups[raw] if raw in silac_groups else fraction_tracker.get_fraction_group(raw, fraction_group)
+            )
             sample, _ = sample_tracker.get_sample_info(source_name)
 
             labels = file2label[raw]
-            label = self._get_label_from_labels(labels, set(labels), label_index, raw, row)
+            label = self._get_label_from_labels(labels, silac_labels, row)
             out = get_openms_file_name(raw, extension_convert)
 
             content += tsv_line(str(frac_group), file2fraction[raw], out, label, str(sample))
@@ -298,6 +355,7 @@ class ExperimentalDesignWriter:
         file2label: dict[str, list[str]],
         extension_convert: str | None,
         file2fraction: dict[str, str],
+        file2fraction_group: dict[str, int] | None = None,
     ):
         """Write one-table format experimental design file.
 
@@ -307,10 +365,18 @@ class ExperimentalDesignWriter:
         cdf = file2label[first_file][0].lower() if file2label[first_file] else ""
         is_multiplex = self._is_multiplex_label(cdf)
 
-        header = self._get_one_table_header(is_multiplex, legacy)
+        # Sample is required for every labeled one-table design. Keep the
+        # legacy flag's existing behavior for label-free output.
+        include_sample = legacy or any(
+            label != "label free sample" for labels in file2label.values() for label in labels
+        )
+        header = self._get_one_table_header(is_multiplex, include_sample)
         content = tsv_line(*header)
 
-        label_index = dict(zip(sdrf["comment[data file]"], [0] * len(sdrf["comment[data file]"])))
+        silac_labels = {
+            label.lower() for labels in file2label.values() for label in labels if label.startswith("SILAC")
+        }
+        silac_groups = self._silac_file_groups(sdrf, file2technical_rep, file2fraction_group)
         fraction_tracker = FractionGroupTracker()
         sample_tracker = SampleIdTracker()
         mixture_tracker = MixtureTracker()
@@ -323,12 +389,14 @@ class ExperimentalDesignWriter:
             fraction_group = self._calculate_fraction_group(
                 source_name, replicate, source_name_list, source_name2n_reps
             )
-            frac_group = fraction_tracker.get_fraction_group(raw, fraction_group)
+            frac_group = (
+                silac_groups[raw] if raw in silac_groups else fraction_tracker.get_fraction_group(raw, fraction_group)
+            )
             sample, bio_replicate = sample_tracker.get_sample_info(source_name)
             condition = self._get_condition(file2combined_factors, raw, row["comment[label]"], source_name)
 
             labels = file2label[raw]
-            label = self._get_label_from_labels(labels, set(labels), label_index, raw, row)
+            label = self._get_label_from_labels(labels, silac_labels, row)
             out = get_openms_file_name(raw, extension_convert)
 
             content += self._format_one_table_row(
@@ -340,7 +408,7 @@ class ExperimentalDesignWriter:
                 condition,
                 bio_replicate,
                 is_multiplex,
-                legacy,
+                include_sample,
                 mixture_tracker,
                 raw,
             )

--- a/src/sdrf_pipelines/converters/openms/openms.py
+++ b/src/sdrf_pipelines/converters/openms/openms.py
@@ -27,6 +27,7 @@ from sdrf_pipelines.converters.openms.utils import (
     FileToColumnEntries,
     infer_itraqplex,
     infer_tmtplex,
+    parse_openms_label,
     parse_tolerance,
 )
 from sdrf_pipelines.utils.utils import tsv_line
@@ -66,7 +67,7 @@ class OpenMS:
         Args:
             sdrf_file: Path to SDRF file
             one_table: If True, write one-table format; otherwise two-table format
-            legacy: If True, include legacy Sample column
+            legacy: Include Sample also for label-free one-table output (always included for labeled data)
             verbose: If True, print verbose output
             split_by_columns: Columns to split output by (comma-separated in brackets)
             extension_convert: File extension conversion pattern
@@ -89,6 +90,7 @@ class OpenMS:
             )
         sdrf = sdrf.astype(str)
         sdrf.columns = sdrf.columns.str.lower()
+        sdrf["comment[label]"] = sdrf["comment[label]"].map(parse_openms_label)
 
         # Get modification columns
         mod_cols = [c for c in sdrf.columns if c.startswith("comment[modification parameters")]
@@ -159,6 +161,9 @@ class OpenMS:
             list_of_combined_factors.append(combined_factors)
 
         sdrf["_conditions_from_factors"] = list_of_combined_factors
+        # Use the complete mixture before splitting by condition: a shared reference
+        # alone cannot identify which mixture a file belongs to.
+        f2c.file2fraction_group = self._design_writer.get_silac_fraction_groups(sdrf, f2c.file2technical_rep)
 
         # Collect warnings from modification converter
         self.warnings.update(self._mod_converter.warnings)
@@ -276,22 +281,13 @@ class OpenMS:
 
     def _process_label(self, row, f2c: FileToColumnEntries, raw: str, sdrf: pd.DataFrame):
         """Process label information."""
-        search_result_label = re.search("NT=(.+?)(;|$)", row["comment[label]"])
-        if search_result_label is not None:
-            label = search_result_label.group(1)
-            f2c.file2label[raw] = [label]
-        else:
-            if "TMT" in row["comment[label]"]:
-                label = sdrf[sdrf["comment[data file]"] == raw]["comment[label]"].tolist()
-            elif "SILAC" in row["comment[label]"]:
-                label = sdrf[sdrf["comment[data file]"] == raw]["comment[label]"].tolist()
-            elif "label free sample" in row["comment[label]"]:
-                label = ["label free sample"]
-            elif "ITRAQ" in row["comment[label]"]:
-                label = sdrf[sdrf["comment[data file]"] == raw]["comment[label]"].tolist()
-            else:
-                raise ValueError("Label " + str(row["comment[label]"]) + " is not recognized")
-            f2c.file2label[raw] = label
+        if raw in f2c.file2label:
+            return
+        labels = sdrf.loc[sdrf["comment[data file]"] == raw, "comment[label]"].tolist()
+        for label in labels:
+            if label != "label free sample" and not label.startswith(("TMT", "SILAC", "ITRAQ")):
+                raise ValueError("Label " + label + " is not recognized")
+        f2c.file2label[raw] = labels
 
     def _combine_factors_to_conditions(self, characteristics_cols, factor_cols, row):
         """Combine factors to create condition strings."""
@@ -340,6 +336,7 @@ class OpenMS:
                 f2c.file2label,
                 extension_convert,
                 f2c.file2fraction,
+                file2fraction_group=f2c.file2fraction_group,
             )
         else:
             self._design_writer.write_two_table_format(
@@ -352,6 +349,7 @@ class OpenMS:
                 extension_convert,
                 f2c.file2fraction,
                 f2c.file2combined_factors,
+                file2fraction_group=f2c.file2fraction_group,
             )
 
     def _write_split_output_files(
@@ -376,6 +374,7 @@ class OpenMS:
                     f2c.file2label,
                     extension_convert,
                     f2c.file2fraction,
+                    file2fraction_group=f2c.file2fraction_group,
                 )
             else:
                 self._design_writer.write_two_table_format(
@@ -388,6 +387,7 @@ class OpenMS:
                     extension_convert,
                     f2c.file2fraction,
                     f2c.file2combined_factors,
+                    file2fraction_group=f2c.file2fraction_group,
                 )
 
     def _save_search_settings_to_file(self, output_filename, sdrf, f2c: FileToColumnEntries):

--- a/src/sdrf_pipelines/converters/openms/utils.py
+++ b/src/sdrf_pipelines/converters/openms/utils.py
@@ -1,11 +1,23 @@
 """Utility functions for OpenMS conversion."""
 
 import logging
+import re
 from collections.abc import Collection
 
 from sdrf_pipelines.converters.openms.constants import CHANNEL_MAP
 
 logger = logging.getLogger(__name__)
+
+
+def parse_openms_label(value: str) -> str:
+    """Read a plain or NT-encoded channel name without discarding other rows."""
+    match = re.search(r"(?:^|;)\s*NT=([^;]+)", value, flags=re.IGNORECASE)
+    label = (match.group(1) if match else value).strip()
+    for channels in CHANNEL_MAP.values():
+        for canonical in channels:
+            if label.casefold() == canonical.casefold():
+                return "label free sample" if canonical == "LFQ" else canonical
+    return label
 
 
 def _infer_plex(label_set: Collection[str], plex_prefix: str) -> str:
@@ -127,3 +139,4 @@ class FileToColumnEntries:
         self.file2fraction: dict[str, str] = {}
         self.file2combined_factors: dict[str, str] = {}
         self.file2technical_rep: dict[str, str] = {}
+        self.file2fraction_group: dict[str, int] = {}

--- a/tests/test_convert_openms_silac.py
+++ b/tests/test_convert_openms_silac.py
@@ -1,0 +1,217 @@
+"""SILAC regression tests exercise the complete SDRF-to-design conversion."""
+
+from io import StringIO
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sdrf_pipelines.converters.openms import OpenMS
+
+FORMATS = [(False, False), (True, False), (True, True)]
+FORMAT_IDS = ["two-table", "one-table", "legacy-one-table"]
+
+
+def make_silac_sdrf(plex: int, layout: str = "pairs") -> pd.DataFrame:
+    """Two mixtures, with known sample identities and conditions per channel."""
+    channels = ["light", "heavy"] if plex == 2 else ["light", "medium", "heavy"]
+    rows = []
+    for mixture in (1, 2):
+        for replicate in (2, 4) if layout == "fractionated" else (1,):
+            for fraction in (1, 2) if layout == "fractionated" else (1,):
+                raw = f"mix{mixture}_rep{replicate}_f{fraction}.raw"
+                for channel in channels:
+                    sample = f"sample{mixture}_{channel}"
+                    if layout == "reference" and channel == "heavy":
+                        sample = "reference"
+                    elif layout == "swap":
+                        sample_channel = channels[::-1][channels.index(channel)] if mixture == 2 else channel
+                        sample = f"sample_{sample_channel}"
+                    rows.append(
+                        {
+                            "source name": sample,
+                            "assay name": raw.removesuffix(".raw"),
+                            "comment[data file]": raw,
+                            "comment[label]": f"SILAC {channel}",
+                            "comment[cleavage agent details]": "NT=Trypsin;AC=MS:1001251",
+                            "comment[fraction identifier]": str(fraction),
+                            "comment[technical replicate]": str(replicate),
+                            "factor value[condition]": sample,
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def convert_design(
+    sdrf: pd.DataFrame, directory: Path, one_table: bool, legacy: bool, split: bool = False
+) -> list[tuple[Path, pd.DataFrame]]:
+    sdrf_path = directory / "silac.sdrf.tsv"
+    sdrf.to_csv(sdrf_path, sep="\t", index=False)
+    OpenMS().openms_convert(
+        str(sdrf_path),
+        one_table=one_table,
+        legacy=legacy,
+        extension_convert="raw:mzML",
+        split_by_columns="[factor value[condition]]" if split else None,
+    )
+    designs = []
+    for path in sorted(directory.glob("experimental_design.tsv*")):
+        sections = path.read_text().strip().split("\n\n")
+        files = pd.read_csv(StringIO(sections[0]), sep="\t", dtype=str)
+        assert "Sample" in files.columns
+        if len(sections) == 2:
+            samples = pd.read_csv(StringIO(sections[1]), sep="\t", dtype=str)
+            files = files.merge(samples, on="Sample", validate="many_to_one")
+        designs.append((path, files))
+    assert designs
+    return designs
+
+
+def assert_design_mapping(sdrf: pd.DataFrame, design: pd.DataFrame, plex: int) -> None:
+    expected_labels = {"SILAC light": "1", "SILAC heavy": "2"}
+    if plex == 3:
+        expected_labels = {"SILAC light": "1", "SILAC medium": "2", "SILAC heavy": "3"}
+    expected = {
+        (row["comment[data file]"].removesuffix(".raw") + ".mzML", expected_labels[row["comment[label]"]]): (
+            row["source name"],
+            row["comment[fraction identifier]"],
+        )
+        for _, row in sdrf.iterrows()
+    }
+    actual = {(row.Spectra_Filepath, row.Label): (row.MSstats_Condition, row.Fraction) for row in design.itertuples()}
+    assert actual == expected
+    assert len(design) == len(expected)
+    assert not design.duplicated(["Spectra_Filepath", "Label"]).any()
+    assert not design.duplicated(["Fraction_Group", "Fraction", "Label"]).any()
+    assert design.groupby("Spectra_Filepath")["Fraction_Group"].nunique().eq(1).all()
+    assert design.groupby("MSstats_Condition")["Sample"].nunique().eq(1).all()
+    assert design.groupby("Sample")["MSstats_Condition"].nunique().eq(1).all()
+    assert sorted(design.Fraction_Group.astype(int).unique()) == list(range(1, design.Fraction_Group.nunique() + 1))
+
+
+@pytest.mark.parametrize("plex", [2, 3])
+@pytest.mark.parametrize("encoding", ["plain", "nt", "mixed"])
+@pytest.mark.parametrize("reverse", [False, True], ids=["forward", "reverse"])
+@pytest.mark.parametrize("one_table,legacy", FORMATS, ids=FORMAT_IDS)
+def test_silac_channels(
+    plex: int, encoding: str, reverse: bool, one_table: bool, legacy: bool, on_tmpdir: Path
+) -> None:
+    expected = make_silac_sdrf(plex)
+    sdrf = expected.copy()
+    # Plain labels and NT syntax may occur in the same SDRF.
+    for i in sdrf.index:
+        if encoding == "nt" or (encoding == "mixed" and i % 2):
+            sdrf.loc[i, "comment[label]"] = f"NT={sdrf.loc[i, 'comment[label]']};"
+    if reverse:
+        sdrf = sdrf.iloc[::-1]
+    _, design = convert_design(sdrf, on_tmpdir, one_table, legacy)[0]
+    assert_design_mapping(expected, design, plex)
+    assert design.Fraction_Group.nunique() == 2
+    settings = pd.read_csv(on_tmpdir / "openms.tsv", sep="\t")
+    assert settings.Label.tolist() == ["SILAC", "SILAC"]
+
+
+@pytest.mark.parametrize("plex", [2, 3])
+@pytest.mark.parametrize("layout", ["reference", "fractionated", "swap"])
+@pytest.mark.parametrize("one_table,legacy", FORMATS, ids=FORMAT_IDS)
+def test_silac_mixtures(plex: int, layout: str, one_table: bool, legacy: bool, on_tmpdir: Path) -> None:
+    sdrf = make_silac_sdrf(plex, layout)
+    # Interleave fractions and mixtures instead of relying on adjacent rows for a raw file.
+    shuffled = sdrf.sample(frac=1, random_state=17)
+    _, design = convert_design(shuffled, on_tmpdir, one_table, legacy)[0]
+    assert_design_mapping(sdrf, design, plex)
+    expected_groups = 4 if layout == "fractionated" else 2
+    assert design.Fraction_Group.nunique() == expected_groups
+    if layout == "fractionated":
+        assert design.groupby("Fraction_Group")["Fraction"].nunique().eq(2).all()
+        # Fractions of the same mixture and replicate belong together, and only those do.
+        run = design.Spectra_Filepath.str.replace(r"_f\d+\.mzML$", "", regex=True)
+        assert design.groupby(run)["Fraction_Group"].nunique().eq(1).all()
+
+
+@pytest.mark.parametrize("one_table,legacy", FORMATS, ids=FORMAT_IDS)
+def test_split_silac_preserves_channels_and_reference_mixtures(one_table: bool, legacy: bool, on_tmpdir: Path) -> None:
+    sdrf = make_silac_sdrf(3, "reference")
+    designs = convert_design(sdrf, on_tmpdir, one_table, legacy, split=True)
+    assert len(designs) == 5
+    for _, design in designs:
+        condition = design.MSstats_Condition.iloc[0]
+        assert_design_mapping(sdrf[sdrf["factor value[condition]"] == condition], design, 3)
+        if condition == "reference":
+            assert design.Fraction_Group.nunique() == 2
+
+
+@pytest.mark.parametrize("one_table,legacy", FORMATS, ids=FORMAT_IDS)
+def test_missing_medium_keeps_three_plex_channel_numbers(one_table: bool, legacy: bool, on_tmpdir: Path) -> None:
+    sdrf = make_silac_sdrf(3)
+    sdrf = sdrf[sdrf["source name"] != "sample2_medium"]
+    _, design = convert_design(sdrf, on_tmpdir, one_table, legacy)[0]
+    assert_design_mapping(sdrf, design, 3)
+
+
+@pytest.mark.parametrize("plex", [2, 3])
+@pytest.mark.parametrize("layout", ["pairs", "reference", "fractionated", "swap"])
+@pytest.mark.parametrize("one_table,legacy", FORMATS, ids=FORMAT_IDS)
+def test_openms_loads_silac_design(plex: int, layout: str, one_table: bool, legacy: bool, on_tmpdir: Path) -> None:
+    oms = pytest.importorskip("pyopenms")
+    sdrf = make_silac_sdrf(plex, layout)
+    path, table = convert_design(sdrf, on_tmpdir, one_table, legacy)[0]
+    design = oms.ExperimentalDesignFile().load(str(path), False)
+    assert design.getNumberOfLabels() == plex
+    assert design.getNumberOfSamples() == sdrf["source name"].nunique()
+    assert design.getNumberOfMSFiles() == sdrf["comment[data file]"].nunique()
+    assert design.getNumberOfFractionGroups() == (4 if layout == "fractionated" else 2)
+    samples = design.getSampleSection()
+    sample_map = {}
+    for entry in design.getMSFileSection():
+        filepath = entry.path.decode() if isinstance(entry.path, bytes) else entry.path
+        sample_map[(filepath, entry.label)] = entry.sample
+    for row in table.itertuples():
+        sample = sample_map[(row.Spectra_Filepath, int(str(row.Label)))]
+        # The 3.5 binding requires an OpenMS String; 3.6 accepts Python strings.
+        factor = oms.String("MSstats_Condition") if oms.__version__.startswith("3.5") else "MSstats_Condition"
+        condition = samples.getFactorValue(sample, factor)
+        if isinstance(condition, bytes):
+            condition = condition.decode()
+        assert condition == row.MSstats_Condition
+
+
+@pytest.mark.parametrize("problem", ["duplicate_channel", "duplicate_acquisition", "fraction", "replicate", "mixed"])
+def test_reject_inconsistent_silac_metadata(problem: str, on_tmpdir: Path) -> None:
+    sdrf = make_silac_sdrf(2)
+    if problem == "duplicate_channel":
+        sdrf = pd.concat([sdrf, sdrf.iloc[[0]]], ignore_index=True)
+    elif problem == "duplicate_acquisition":
+        repeated = sdrf.iloc[:2].copy()
+        repeated["comment[data file]"] = "repeat.raw"
+        sdrf = pd.concat([sdrf, repeated], ignore_index=True)
+    elif problem == "fraction":
+        sdrf.loc[0, "comment[fraction identifier]"] = "2"
+    elif problem == "replicate":
+        sdrf.loc[0, "comment[technical replicate]"] = "2"
+    else:
+        sdrf.loc[sdrf["comment[data file]"].str.startswith("mix2"), "comment[label]"] = "label free sample"
+    with pytest.raises(ValueError):
+        convert_design(sdrf, on_tmpdir, False, False)
+    assert not (on_tmpdir / "experimental_design.tsv").exists()
+
+
+def test_existing_silac_cv_fixture(on_tmpdir: Path) -> None:
+    sdrf = pd.read_csv(Path(__file__).parent / "data/diann/silac_2plex.sdrf.tsv", sep="\t", dtype=str)
+    # The repository fixture has full NT/AC annotations and no fraction/replicate columns.
+    _, design = convert_design(sdrf, on_tmpdir, False, False)[0]
+    assert design.Label.tolist() == ["1", "2"]
+    assert design.Sample.tolist() == ["1", "2"]
+    assert design.Fraction.tolist() == ["1", "1"]
+    assert design.Fraction_Group.tolist() == ["1", "1"]
+
+
+@pytest.mark.parametrize("labels", [("TMT126", "TMT127"), ("ITRAQ114", "ITRAQ115")])
+@pytest.mark.parametrize("one_table,legacy", FORMATS, ids=FORMAT_IDS)
+def test_other_multiplex_cv_labels(labels: tuple[str, str], one_table: bool, legacy: bool, on_tmpdir: Path) -> None:
+    sdrf = make_silac_sdrf(2)
+    sdrf["comment[label]"] = [f"NT={labels[0]};", f"NT={labels[1]};"] * 2
+    sdrf = sdrf.iloc[::-1]
+    _, design = convert_design(sdrf, on_tmpdir, one_table, legacy)[0]
+    assert design.Label.tolist() == ["2", "1", "2", "1"]
+    assert design.MSstats_Condition.tolist() == sdrf["factor value[condition]"].tolist()


### PR DESCRIPTION
SILAC SDRFs currently produce experimental designs that OpenMS rejects: plain channel names repeat the first channel, while NT-encoded names overwrite the per-file label list and repeat the last channel. Shared-reference mixtures can also receive inconsistent fraction groups, and modern one-table output omits the Sample column required for labeled data.

This PR fixes these cases and adds regression coverage.

### Changes

- Normalize plain and NT-encoded label names before collecting all channels for each raw file.
- Map each row directly to its channel, independently of row ordering and condition subsets.
- Infer SILAC channel numbering from the complete input: light/heavy use 1/2; when medium is present, light/medium/heavy use 1/2/3. A missing medium row in another file or a condition split does not renumber heavy.
- Group SILAC fractions by the complete channel-to-source assignment and technical replicate. This keeps shared references in their respective mixtures and distinguishes label swaps.
- Compute mixture groups before condition splitting, then renumber the selected groups consecutively for OpenMS.
- Include Sample in every labeled one-table design while retaining the existing label-free legacy behavior.
- Reject duplicate channels/acquisitions, inconsistent fraction or replicate metadata within a raw file, and inputs mixing SILAC with other labeling methods, instead of producing invalid tables.

### Tests

The new test module contains 96 parameterized cases covering:
- Two- and three-channel SILAC, plain/NT/mixed annotations, reversed and shuffled rows.
- Two-table, modern one-table, and legacy one-table output.
- Shared references, fractionation, nonconsecutive technical replicate identifiers, and label swaps.
- Condition splits, missing medium rows, the existing SILAC CV fixture, and invalid metadata.
- TMT/iTRAQ CV-label compatibility, since they share label handling.
- 24 integration cases that load generated designs with OpenMS and verify sample/condition mappings as well as file, label, sample, and fraction-group counts.

The initial 60 structural regression cases all failed on main before the fixes.

A dedicated CI job installs pyOpenMS 3.5.0 and runs the new module, so the OpenMS-loading checks run in CI without adding pyOpenMS to the package's runtime dependencies.

### Validation

- `uv run --with pyopenms==3.5.0 pytest tests/test_convert_openms_silac.py -q`: **96 passed**.
- pyOpenMS `3.6.0.dev20260907`: all **24 integration/loading cases passed**; the full new module was also checked with this development build.
- `uv run pytest -m 'not ontology' --ignore=tests/test_sdrfchecker.py --ignore=tests/test_skip_ontology.py -q`: **442 passed, 24 skipped, 49 deselected**. The skipped cases are the optional pyOpenMS integration tests, run separately above.
- `uv run pre-commit run --all-files`: **all hooks passed**, including mypy.

The two excluded validator modules perform ontology network lookups despite not being marked as ontology tests; the unrestricted core run stalled there. Ontology validation was not changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenMS conversion for SILAC, TMT, and iTRAQ designs, including more reliable label recognition and fraction grouping.
  * Preserved distinct SILAC mixtures and included sample information for labeled experiments.
  * Added support for loading and validating a wider range of label formats and experimental layouts.

* **Bug Fixes**
  * Improved handling of inconsistent, duplicate, unsupported, and mixed labeling metadata.

* **Tests**
  * Added comprehensive SILAC conversion coverage and automated OpenMS design validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->